### PR TITLE
security: harden workflows and add fuzz tests for Scorecard

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -9,15 +9,16 @@ on:
     - cron: "0 6 * * 1"
   workflow_dispatch:
 
-permissions:
-  security-events: write
-  actions: read
-  contents: read
+permissions: read-all
 
 jobs:
   analyze:
     name: Analyze
     runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      actions: read
+      contents: read
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -3,14 +3,15 @@ name: Dependabot Auto-Merge
 on:
   pull_request:
 
-permissions:
-  pull-requests: write
-  contents: write
+permissions: read-all
 
 jobs:
   automerge:
     name: Auto-Merge Patch Updates
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: write
     if: github.actor == 'dependabot[bot]'
     steps:
       - name: Fetch Dependabot metadata

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,15 +5,16 @@ on:
     tags:
       - "v*"
 
-permissions:
-  contents: write
-  id-token: write
-  attestations: write
+permissions: read-all
 
 jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+      attestations: write
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,7 +41,7 @@ jobs:
         with:
           go-version: "1.26"
       - name: Install golangci-lint
-        run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
+        run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.8
       - name: Run golangci-lint
         run: golangci-lint run ./...
 
@@ -64,10 +64,10 @@ jobs:
         with:
           go-version: "1.26"
       - name: Install govulncheck
-        run: go install golang.org/x/vuln/cmd/govulncheck@latest
+        run: go install golang.org/x/vuln/cmd/govulncheck@v1.1.4
       - name: Run govulncheck
         run: govulncheck ./...
       - name: Install gosec
-        run: go install github.com/securego/gosec/v2/cmd/gosec@latest
+        run: go install github.com/securego/gosec/v2/cmd/gosec@v2.25.0
       - name: Run gosec
         run: gosec -exclude=G304 ./...

--- a/internal/provider/inputvalidation/helpers_fuzz_test.go
+++ b/internal/provider/inputvalidation/helpers_fuzz_test.go
@@ -1,0 +1,73 @@
+// Copyright (c) 2026 Alex Ackerman
+// SPDX-License-Identifier: MPL-2.0
+
+package inputvalidation
+
+import "testing"
+
+// FuzzIsValidIPv4 exercises IPv4 validation with arbitrary input.
+func FuzzIsValidIPv4(f *testing.F) {
+	f.Add("192.168.1.1")
+	f.Add("10.0.0.0")
+	f.Add("255.255.255.255")
+	f.Add("0.0.0.0")
+	f.Add("::1")
+	f.Add("not-an-ip")
+	f.Add("")
+	f.Add("192.168.1.1/24")
+	f.Add("999.999.999.999")
+
+	f.Fuzz(func(t *testing.T, s string) {
+		// Must not panic on any input.
+		_ = isValidIPv4(s)
+	})
+}
+
+// FuzzIsValidIPv6 exercises IPv6 validation with arbitrary input.
+func FuzzIsValidIPv6(f *testing.F) {
+	f.Add("::1")
+	f.Add("2001:db8::1")
+	f.Add("fe80::1%eth0")
+	f.Add("192.168.1.1")
+	f.Add("")
+	f.Add("::ffff:192.168.1.1")
+	f.Add("not-an-ip")
+
+	f.Fuzz(func(t *testing.T, s string) {
+		_ = isValidIPv6(s)
+	})
+}
+
+// FuzzIsValidFQDN exercises FQDN validation with arbitrary input.
+func FuzzIsValidFQDN(f *testing.F) {
+	f.Add("example.com")
+	f.Add("example.com.")
+	f.Add("sub.domain.example.com")
+	f.Add("localhost")
+	f.Add("")
+	f.Add(".")
+	f.Add("..")
+	f.Add("-invalid.com")
+	f.Add("192.168.1.1")
+	f.Add("_dmarc.example.com")
+
+	f.Fuzz(func(t *testing.T, s string) {
+		_ = isValidFQDN(s)
+	})
+}
+
+// FuzzIsValidHostname exercises hostname validation with arbitrary input.
+func FuzzIsValidHostname(f *testing.F) {
+	f.Add("myhost")
+	f.Add("my-host.example.com")
+	f.Add("localhost")
+	f.Add("")
+	f.Add("192.168.1.1")
+	f.Add("_srv.example.com")
+	f.Add("-bad")
+	f.Add(string(make([]byte, 256)))
+
+	f.Fuzz(func(t *testing.T, s string) {
+		_ = isValidHostname(s)
+	})
+}

--- a/internal/provider/tfpath/tfpath_fuzz_test.go
+++ b/internal/provider/tfpath/tfpath_fuzz_test.go
@@ -1,0 +1,44 @@
+// Copyright (c) 2026 Alex Ackerman
+// SPDX-License-Identifier: MPL-2.0
+
+package tfpath
+
+import "testing"
+
+// FuzzParse exercises the dot-path parser with arbitrary input to detect
+// panics, out-of-bounds access, or unexpected behavior on malformed paths.
+func FuzzParse(f *testing.F) {
+	// Seed corpus: realistic paths and edge cases
+	f.Add("dnssec.enabled")
+	f.Add("name")
+	f.Add("dnssec.algorithm")
+	f.Add("recursion_network_acl")
+	f.Add("")
+	f.Add(".")
+	f.Add("..")
+	f.Add("a.b.c.d.e.f")
+	f.Add("......")
+
+	f.Fuzz(func(t *testing.T, dotPath string) {
+		// Parse must not panic on any input.
+		_ = Parse(dotPath)
+	})
+}
+
+// FuzzParent exercises the parent-path extractor with arbitrary input.
+func FuzzParent(f *testing.F) {
+	f.Add("dnssec.enabled")
+	f.Add("name")
+	f.Add("")
+	f.Add(".")
+	f.Add("a.b.c")
+
+	f.Fuzz(func(t *testing.T, dotPath string) {
+		result := Parent(dotPath)
+		// Parent must always return a string shorter than input
+		// (or empty for top-level paths).
+		if len(result) >= len(dotPath) && dotPath != "" {
+			t.Errorf("Parent(%q) = %q, expected shorter string", dotPath, result)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

- **Token Permissions (alerts 1-3):** Move write permissions from workflow-level to job-level in codeql, dependabot-automerge, and release workflows. Top-level defaults to `permissions: read-all` per Scorecard requirements.
- **Pinned Dependencies (alerts 4-6):** Pin `golangci-lint` (v1.64.8), `govulncheck` (v1.1.4), and `gosec` (v2.25.0) to specific versions instead of `@latest`.
- **Fuzzing (alert 10):** Add Go native fuzz tests for `tfpath.Parse`, `tfpath.Parent`, `isValidIPv4`, `isValidIPv6`, `isValidFQDN`, `isValidHostname`.

### Alerts Not Addressable in Code

| Alert | Issue | Resolution |
|-------|-------|------------|
| #7 Code-Review | No approved changesets | Enable branch protection requiring PR review approvals |
| #8 Maintained | Project < 90 days old | Time resolves this |
| #9 CII-Best-Practices | No OpenSSF badge | Register at bestpractices.coreinfrastructure.org |

## Test Plan

- [x] `go vet ./...` — clean
- [x] `golangci-lint run ./...` (v1.64.8) — clean
- [x] All unit tests pass
- [x] Fuzz tests run without panics (3s each, ~1.3M executions total)
- [ ] Verify Scorecard re-runs after merge and alerts close

🤖 Generated with [Claude Code](https://claude.com/claude-code)