### PR TITLE
chore: migrate golangci-lint from v1 to v2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,7 +41,7 @@ jobs:
         with:
           go-version: "1.26"
       - name: Install golangci-lint
-        run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.8
+        run: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.4
       - name: Run golangci-lint
         run: golangci-lint run ./...
 

--- a/internal/client/blocked.go
+++ b/internal/client/blocked.go
@@ -29,7 +29,7 @@ func exportFilteredZones(c *Client, path string) ([]string, error) {
 	if err != nil {
 		return nil, fmt.Errorf("request to %s failed: %w", path, err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -182,7 +182,7 @@ func (c *Client) doGet(path string, params url.Values) (*APIResponse, error) {
 	if err != nil {
 		return nil, fmt.Errorf("request to %s failed: %w", path, err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	return c.parseResponse(resp)
 }
@@ -199,7 +199,7 @@ func (c *Client) doPost(path string, params url.Values) (*APIResponse, error) {
 	if err != nil {
 		return nil, fmt.Errorf("request to %s failed: %w", path, err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	return c.parseResponse(resp)
 }

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -288,7 +288,7 @@ func TestNewClient_CACertFile_Valid(t *testing.T) {
 	if _, err := f.Write(certPEM); err != nil {
 		t.Fatal(err)
 	}
-	f.Close()
+	_ = f.Close()
 
 	c, err := NewClient(ClientConfig{
 		BaseURL:    "https://localhost:5380",
@@ -326,7 +326,7 @@ func TestNewClient_CACertFile_InvalidPEM(t *testing.T) {
 	if _, err := f.WriteString("this is not valid PEM data"); err != nil {
 		t.Fatal(err)
 	}
-	f.Close()
+	_ = f.Close()
 
 	_, err = NewClient(ClientConfig{
 		BaseURL:    "https://localhost:5380",
@@ -428,7 +428,7 @@ func TestNewClient_CACertFileAndDir_Combined(t *testing.T) {
 	if _, err := f.Write(certPEM1); err != nil {
 		t.Fatal(err)
 	}
-	f.Close()
+	_ = f.Close()
 
 	if err := os.WriteFile(filepath.Join(dir, "ca2.pem"), certPEM2, 0600); err != nil {
 		t.Fatal(err)

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -463,7 +463,7 @@ func validateCategorization(cat *CategorizationModel, nss bool) (Categorization,
 	}
 
 	// Rule: NSS requires all three objectives
-	if nss && !(hasConf && hasInteg && hasAvail) {
+	if nss && (!hasConf || !hasInteg || !hasAvail) {
 		diags.AddError("Incomplete NSS categorization",
 			"National Security Systems require all three objectives: confidentiality, integrity, and availability.")
 		return result, diags


### PR DESCRIPTION
## Summary

Migrates golangci-lint from v1.64.8 to v2.11.4 and resolves all lint findings surfaced by the stricter v2 defaults.

Closes #12

### Changes

- **CI:** Updated `go install` path from `github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.8` to `github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.4`
- **errcheck fixes (6):** `resp.Body.Close()` and `f.Close()` return values now explicitly handled
- **staticcheck fix (1):** De Morgan's law applied to NSS categorization check in provider.go

### Files changed

| File | Fix |
|------|-----|
| `.github/workflows/test.yml` | v2 install path |
| `internal/client/blocked.go` | `defer func() { _ = resp.Body.Close() }()` |
| `internal/client/client.go` | Same pattern, 2 occurrences |
| `internal/client/client_test.go` | `_ = f.Close()`, 3 occurrences |
| `internal/provider/provider.go` | `!(a && b && c)` → `(!a \|\| !b \|\| !c)` |

## Test plan

- [x] `golangci-lint run ./...` — 0 issues (was 7)
- [x] `go build ./...` — clean
- [x] `go test ./internal/client/ -v` — all pass
- [x] CI lint job uses v2

🤖 Generated with [Claude Code](https://claude.com/claude-code)