### PR TITLE
chore: add golangci-lint v2 config with security and nil-safety linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,62 @@
+# Filename: .golangci.yml
+# Last Modified: 2026-03-29
+# Summary: golangci-lint v2 configuration for DoD STIG-compliant Terraform provider
+# Compliant With: DoD STIG, NIST SP800-53 Rev 5 (SA-11, SI-2, SI-10)
+# Classification: UNCLASSIFIED
+
+version: "2"
+
+linters:
+  enable:
+    # --- Nil-safety (SA-11: Developer Testing and Evaluation) ---
+    - nilerr          # Catches return nil when error is non-nil
+    - nilnesserr      # Catches err != nil checks that return a different nil error
+    - nilnil          # Catches simultaneous return of nil error and nil value
+
+    # --- Error handling (SI-2: Flaw Remediation) ---
+    - errorlint       # Finds issues with error wrapping (Go 1.13+ errors.Is/As)
+    - bodyclose       # Checks HTTP response body is closed (resource leak prevention)
+
+    # --- Security (SI-10: Information Input Validation) ---
+    - gosec           # Security-focused static analysis
+    - bidichk         # Detects dangerous unicode bidi character sequences (trojan source)
+    - forcetypeassert # Finds forced type assertions that can panic
+
+    # --- Correctness ---
+    - gocritic        # Broad diagnostics for bugs, performance, and style
+    - durationcheck   # Catches two durations multiplied together (common time bug)
+    - copyloopvar     # Detects loop variable copy issues
+    - fatcontext      # Detects nested contexts in loops (resource leak)
+    - musttag         # Enforces field tags in marshaled structs
+
+    # --- Code quality ---
+    - misspell        # Catches misspelled English words in comments and strings
+    - nakedret        # Checks functions with naked returns aren't too long
+    - unconvert       # Removes unnecessary type conversions
+
+  settings:
+    gosec:
+      excludes:
+        - G304  # File path provided as taint input (expected for CA cert loading)
+    nakedret:
+      max-func-lines: 30
+    gocritic:
+      enabled-tags:
+        - diagnostic
+        - performance
+      disabled-checks:
+        # Terraform Plugin Framework dictates method signatures with value receivers
+        # for resource.CreateRequest, resource.ReadRequest, etc. These are not
+        # modifiable by provider authors.
+        - hugeParam
+        # if-else chains in provider configuration logic are clearer than switch
+        # statements when conditions involve nil checks and boolean combinations
+        - ifElseChain
+
+  exclusions:
+    rules:
+      - path: _test\.go
+        linters:
+          - gosec           # Test files legitimately use hardcoded test values
+          - forcetypeassert # Test assertions often use direct type assertions
+          - errorlint       # Test error checks use type assertions for clarity

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -122,7 +122,7 @@ func NewClient(cfg ClientConfig) (*Client, error) {
 // certDir was specified (certFile parse failures are always fatal).
 func loadCACerts(certFile, certDir string) (*x509.CertPool, error) {
 	if certFile == "" && certDir == "" {
-		return nil, nil
+		return nil, nil //nolint:nilnil // nil pool signals "use system CA defaults" to caller
 	}
 	pool := x509.NewCertPool()
 	loaded := 0

--- a/internal/provider/validators/stig_engine.go
+++ b/internal/provider/validators/stig_engine.go
@@ -39,8 +39,8 @@ type Engine struct {
 // NewEngine constructs an engine from config, indexing all requirements.
 func NewEngine(config EngineConfig) *Engine {
 	reqs := make(map[string]DNSSecurityRequirement, len(DNSSecurityRequirements))
-	for _, req := range DNSSecurityRequirements {
-		reqs[req.ID] = req
+	for i := range DNSSecurityRequirements {
+		reqs[DNSSecurityRequirements[i].ID] = DNSSecurityRequirements[i]
 	}
 	return &Engine{
 		config:       config,


### PR DESCRIPTION
## Summary

Adds a `.golangci.yml` configuration enabling 16 additional linters beyond golangci-lint v2 defaults, focused on security, nil-safety, and correctness for a DoD STIG-compliant Terraform provider.

### Linters Enabled

| Category | Linters | NIST Control |
|----------|---------|--------------|
| **Nil-safety** | nilerr, nilnesserr, nilnil | SA-11 |
| **Error handling** | errorlint, bodyclose | SI-2 |
| **Security** | gosec, bidichk, forcetypeassert | SI-10 |
| **Correctness** | gocritic, durationcheck, copyloopvar, fatcontext, musttag | — |
| **Quality** | misspell, nakedret, unconvert | — |

### Fixes

- `rangeValCopy` in `stig_engine.go` — was copying 128 bytes per iteration in the requirements loop
- `nilnil` nolint directive on `loadCACerts` — intentional `nil, nil` return signals "use system CA defaults"

### Terraform Provider Tuning

- `hugeParam` excluded — Terraform Plugin Framework dictates value receiver signatures
- `ifElseChain` excluded — config validation logic is clearer as if-else than switch
- Test exclusions for gosec, forcetypeassert, errorlint

## Test plan

- [x] `golangci-lint run ./...` — 0 issues
- [x] `golangci-lint config verify` — valid config
- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] STIG engine tests pass


🤖 Generated with [Claude Code](https://claude.com/claude-code)