### PR TITLE
fix: propagate context.Context through HTTP client methods

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -23,6 +23,7 @@ linters:
     - forcetypeassert # Finds forced type assertions that can panic
 
     # --- Correctness ---
+    - noctx           # Detects HTTP requests without context.Context
     - gocritic        # Broad diagnostics for bugs, performance, and style
     - durationcheck   # Catches two durations multiplied together (common time bug)
     - copyloopvar     # Detects loop variable copy issues

--- a/internal/client/allowed.go
+++ b/internal/client/allowed.go
@@ -4,6 +4,7 @@
 package client
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/url"
@@ -11,26 +12,26 @@ import (
 )
 
 // AllowedZoneAdd adds a domain to the allowed zone list. Idempotent.
-func (c *Client) AllowedZoneAdd(domain string) error {
+func (c *Client) AllowedZoneAdd(ctx context.Context, domain string) error {
 	params := url.Values{}
 	params.Set("domain", domain)
-	_, err := c.doGet("/api/allowed/add", params)
+	_, err := c.doGet(ctx, "/api/allowed/add", params)
 	return err
 }
 
 // AllowedZoneDelete removes a domain from the allowed zone list. Idempotent.
-func (c *Client) AllowedZoneDelete(domain string) error {
+func (c *Client) AllowedZoneDelete(ctx context.Context, domain string) error {
 	params := url.Values{}
 	params.Set("domain", domain)
-	_, err := c.doGet("/api/allowed/delete", params)
+	_, err := c.doGet(ctx, "/api/allowed/delete", params)
 	return err
 }
 
 // AllowedZoneExists checks whether a domain exists in the allowed zone list.
-func (c *Client) AllowedZoneExists(domain string) (bool, error) {
+func (c *Client) AllowedZoneExists(ctx context.Context, domain string) (bool, error) {
 	params := url.Values{}
 	params.Set("domain", domain)
-	resp, err := c.doGet("/api/allowed/list", params)
+	resp, err := c.doGet(ctx, "/api/allowed/list", params)
 	if err != nil {
 		return false, err
 	}
@@ -44,20 +45,20 @@ func (c *Client) AllowedZoneExists(domain string) (bool, error) {
 }
 
 // AllowedZoneList returns all domains in the allowed zone list.
-func (c *Client) AllowedZoneList() ([]string, error) {
-	return exportFilteredZones(c, "/api/allowed/export")
+func (c *Client) AllowedZoneList(ctx context.Context) ([]string, error) {
+	return exportFilteredZones(ctx, c, "/api/allowed/export")
 }
 
 // AllowedZoneImport replaces the allowed zone list with the given domains.
-func (c *Client) AllowedZoneImport(domains []string) error {
+func (c *Client) AllowedZoneImport(ctx context.Context, domains []string) error {
 	params := url.Values{}
 	params.Set("allowedZones", strings.Join(domains, ","))
-	_, err := c.doGet("/api/allowed/import", params)
+	_, err := c.doGet(ctx, "/api/allowed/import", params)
 	return err
 }
 
 // AllowedZoneFlush clears all entries from the allowed zone list.
-func (c *Client) AllowedZoneFlush() error {
-	_, err := c.doGet("/api/allowed/flush", nil)
+func (c *Client) AllowedZoneFlush(ctx context.Context) error {
+	_, err := c.doGet(ctx, "/api/allowed/flush", nil)
 	return err
 }

--- a/internal/client/blocked.go
+++ b/internal/client/blocked.go
@@ -4,9 +4,11 @@
 package client
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
+	"net/http"
 	"net/url"
 	"strings"
 )
@@ -23,9 +25,13 @@ type filteredZoneListResponse struct {
 // (e.g. /api/blocked/export or /api/allowed/export) and returns one domain
 // per line. It bypasses doGet because the export endpoint returns plain text,
 // not JSON.
-func exportFilteredZones(c *Client, path string) ([]string, error) {
+func exportFilteredZones(ctx context.Context, c *Client, path string) ([]string, error) {
 	reqURL := fmt.Sprintf("%s%s?token=%s", c.baseURL, path, url.QueryEscape(c.token))
-	resp, err := c.httpClient.Get(reqURL)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("creating request to %s: %w", path, err)
+	}
+	resp, err := c.httpClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("request to %s failed: %w", path, err)
 	}
@@ -53,10 +59,10 @@ func exportFilteredZones(c *Client, path string) ([]string, error) {
 }
 
 // BlockedZoneAdd adds a domain to the blocked zone list. Idempotent.
-func (c *Client) BlockedZoneAdd(domain string) error {
+func (c *Client) BlockedZoneAdd(ctx context.Context, domain string) error {
 	params := url.Values{}
 	params.Set("domain", domain)
-	_, err := c.doGet("/api/blocked/add", params)
+	_, err := c.doGet(ctx, "/api/blocked/add", params)
 	if err != nil {
 		return fmt.Errorf("adding blocked zone %q: %w", domain, err)
 	}
@@ -64,10 +70,10 @@ func (c *Client) BlockedZoneAdd(domain string) error {
 }
 
 // BlockedZoneDelete removes a domain from the blocked zone list. Idempotent.
-func (c *Client) BlockedZoneDelete(domain string) error {
+func (c *Client) BlockedZoneDelete(ctx context.Context, domain string) error {
 	params := url.Values{}
 	params.Set("domain", domain)
-	_, err := c.doGet("/api/blocked/delete", params)
+	_, err := c.doGet(ctx, "/api/blocked/delete", params)
 	if err != nil {
 		return fmt.Errorf("deleting blocked zone %q: %w", domain, err)
 	}
@@ -75,10 +81,10 @@ func (c *Client) BlockedZoneDelete(domain string) error {
 }
 
 // BlockedZoneExists returns true if the domain exists in the blocked zone list.
-func (c *Client) BlockedZoneExists(domain string) (bool, error) {
+func (c *Client) BlockedZoneExists(ctx context.Context, domain string) (bool, error) {
 	params := url.Values{}
 	params.Set("domain", domain)
-	apiResp, err := c.doGet("/api/blocked/list", params)
+	apiResp, err := c.doGet(ctx, "/api/blocked/list", params)
 	if err != nil {
 		return false, fmt.Errorf("checking blocked zone %q: %w", domain, err)
 	}
@@ -92,8 +98,8 @@ func (c *Client) BlockedZoneExists(domain string) (bool, error) {
 }
 
 // BlockedZoneList returns all domains in the blocked zone list.
-func (c *Client) BlockedZoneList() ([]string, error) {
-	domains, err := exportFilteredZones(c, "/api/blocked/export")
+func (c *Client) BlockedZoneList(ctx context.Context) ([]string, error) {
+	domains, err := exportFilteredZones(ctx, c, "/api/blocked/export")
 	if err != nil {
 		return nil, fmt.Errorf("listing blocked zones: %w", err)
 	}
@@ -101,10 +107,10 @@ func (c *Client) BlockedZoneList() ([]string, error) {
 }
 
 // BlockedZoneImport adds multiple domains to the blocked zone list in one call.
-func (c *Client) BlockedZoneImport(domains []string) error {
+func (c *Client) BlockedZoneImport(ctx context.Context, domains []string) error {
 	params := url.Values{}
 	params.Set("blockedZones", strings.Join(domains, ","))
-	_, err := c.doGet("/api/blocked/import", params)
+	_, err := c.doGet(ctx, "/api/blocked/import", params)
 	if err != nil {
 		return fmt.Errorf("importing blocked zones: %w", err)
 	}
@@ -112,8 +118,8 @@ func (c *Client) BlockedZoneImport(domains []string) error {
 }
 
 // BlockedZoneFlush removes all domains from the blocked zone list.
-func (c *Client) BlockedZoneFlush() error {
-	_, err := c.doGet("/api/blocked/flush", nil)
+func (c *Client) BlockedZoneFlush(ctx context.Context) error {
+	_, err := c.doGet(ctx, "/api/blocked/flush", nil)
 	if err != nil {
 		return fmt.Errorf("flushing blocked zones: %w", err)
 	}

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -4,6 +4,7 @@
 package client
 
 import (
+	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/json"
@@ -171,14 +172,18 @@ func loadCACerts(certFile, certDir string) (*x509.CertPool, error) {
 
 // doGet performs a GET request to the Technitium API and returns the parsed response.
 // Most Technitium API endpoints use GET with query parameters, including mutations.
-func (c *Client) doGet(path string, params url.Values) (*APIResponse, error) {
+func (c *Client) doGet(ctx context.Context, path string, params url.Values) (*APIResponse, error) {
 	if params == nil {
 		params = url.Values{}
 	}
 	params.Set("token", c.token)
 
 	reqURL := fmt.Sprintf("%s%s?%s", c.baseURL, path, params.Encode())
-	resp, err := c.httpClient.Get(reqURL)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("creating request to %s: %w", path, err)
+	}
+	resp, err := c.httpClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("request to %s failed: %w", path, err)
 	}
@@ -188,14 +193,20 @@ func (c *Client) doGet(path string, params url.Values) (*APIResponse, error) {
 }
 
 // doPost performs a POST request with form-encoded body (used by /api/settings/set).
-func (c *Client) doPost(path string, params url.Values) (*APIResponse, error) {
+func (c *Client) doPost(ctx context.Context, path string, params url.Values) (*APIResponse, error) {
 	if params == nil {
 		params = url.Values{}
 	}
 	params.Set("token", c.token)
 
 	reqURL := fmt.Sprintf("%s%s", c.baseURL, path)
-	resp, err := c.httpClient.PostForm(reqURL, params)
+	body := strings.NewReader(params.Encode())
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, reqURL, body)
+	if err != nil {
+		return nil, fmt.Errorf("creating request to %s: %w", path, err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	resp, err := c.httpClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("request to %s failed: %w", path, err)
 	}
@@ -234,11 +245,11 @@ func (c *Client) parseResponse(resp *http.Response) (*APIResponse, error) {
 // Uses /api/user/session/get which exists across all Technitium versions and
 // validates the token without side effects. Falls back to /api/settings/get
 // if the session endpoint is unavailable.
-func (c *Client) Ping() error {
-	_, err := c.doGet("/api/user/session/get", nil)
+func (c *Client) Ping(ctx context.Context) error {
+	_, err := c.doGet(ctx, "/api/user/session/get", nil)
 	if err != nil {
 		// Fallback: try settings endpoint (always exists, requires valid token)
-		_, err = c.doGet("/api/settings/get", nil)
+		_, err = c.doGet(ctx, "/api/settings/get", nil)
 	}
 	return err
 }

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -4,6 +4,7 @@
 package client
 
 import (
+	"context"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
@@ -89,7 +90,7 @@ func TestDoGet_Success(t *testing.T) {
 	defer ts.Close()
 
 	c, _ := NewClient(ClientConfig{BaseURL: ts.URL, Token: "test-token"})
-	resp, err := c.doGet("/api/zones/list", nil)
+	resp, err := c.doGet(context.Background(), "/api/zones/list", nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -110,7 +111,7 @@ func TestDoGet_APIError(t *testing.T) {
 	defer ts.Close()
 
 	c, _ := NewClient(ClientConfig{BaseURL: ts.URL, Token: "test-token"})
-	_, err := c.doGet("/api/zones/options/get", nil)
+	_, err := c.doGet(context.Background(), "/api/zones/options/get", nil)
 	if err == nil {
 		t.Fatal("expected error")
 	}
@@ -135,7 +136,7 @@ func TestDoGet_InvalidToken(t *testing.T) {
 	defer ts.Close()
 
 	c, _ := NewClient(ClientConfig{BaseURL: ts.URL, Token: "bad-token"})
-	_, err := c.doGet("/api/zones/list", nil)
+	_, err := c.doGet(context.Background(), "/api/zones/list", nil)
 	if err == nil {
 		t.Fatal("expected error")
 	}
@@ -158,7 +159,7 @@ func TestDoGet_HTTPError(t *testing.T) {
 	defer ts.Close()
 
 	c, _ := NewClient(ClientConfig{BaseURL: ts.URL, Token: "test-token"})
-	_, err := c.doGet("/api/zones/list", nil)
+	_, err := c.doGet(context.Background(), "/api/zones/list", nil)
 	if err == nil {
 		t.Fatal("expected error for HTTP 500")
 	}
@@ -173,7 +174,7 @@ func TestDoGet_InvalidJSON(t *testing.T) {
 	defer ts.Close()
 
 	c, _ := NewClient(ClientConfig{BaseURL: ts.URL, Token: "test-token"})
-	_, err := c.doGet("/api/zones/list", nil)
+	_, err := c.doGet(context.Background(), "/api/zones/list", nil)
 	if err == nil {
 		t.Fatal("expected error for invalid JSON")
 	}
@@ -198,7 +199,7 @@ func TestDoPost_Success(t *testing.T) {
 
 	c, _ := NewClient(ClientConfig{BaseURL: ts.URL, Token: "test-token"})
 	params := url.Values{"setting": {"value1"}}
-	resp, err := c.doPost("/api/settings/set", params)
+	resp, err := c.doPost(context.Background(), "/api/settings/set", params)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -219,7 +220,7 @@ func TestDoPost_APIError(t *testing.T) {
 	defer ts.Close()
 
 	c, _ := NewClient(ClientConfig{BaseURL: ts.URL, Token: "test-token"})
-	_, err := c.doPost("/api/settings/set", nil)
+	_, err := c.doPost(context.Background(), "/api/settings/set", nil)
 	if err == nil {
 		t.Fatal("expected error")
 	}
@@ -234,7 +235,7 @@ func TestPing_Success(t *testing.T) {
 	defer ts.Close()
 
 	c, _ := NewClient(ClientConfig{BaseURL: ts.URL, Token: "test-token"})
-	if err := c.Ping(); err != nil {
+	if err := c.Ping(context.Background()); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
@@ -251,7 +252,7 @@ func TestPing_InvalidToken(t *testing.T) {
 	defer ts.Close()
 
 	c, _ := NewClient(ClientConfig{BaseURL: ts.URL, Token: "bad-token"})
-	if err := c.Ping(); err == nil {
+	if err := c.Ping(context.Background()); err == nil {
 		t.Fatal("expected error for invalid token")
 	}
 }

--- a/internal/client/records.go
+++ b/internal/client/records.go
@@ -4,6 +4,7 @@
 package client
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/url"
@@ -41,7 +42,7 @@ type RecordGetResponse struct {
 //   - PTR: "ptrName"
 //   - NS: "nameServer"
 //   - CAA: "flags", "tag", "value"
-func (c *Client) RecordAdd(domain, zone, recordType string, ttl int, overwrite bool, params map[string]string) (*Record, error) {
+func (c *Client) RecordAdd(ctx context.Context, domain, zone, recordType string, ttl int, overwrite bool, params map[string]string) (*Record, error) {
 	qp := url.Values{
 		"domain": {domain},
 		"zone":   {zone},
@@ -57,7 +58,7 @@ func (c *Client) RecordAdd(domain, zone, recordType string, ttl int, overwrite b
 		qp.Set(k, v)
 	}
 
-	resp, err := c.doGet("/api/zones/records/add", qp)
+	resp, err := c.doGet(ctx, "/api/zones/records/add", qp)
 	if err != nil {
 		return nil, fmt.Errorf("adding %s record for %q in zone %q: %w", recordType, domain, zone, err)
 	}
@@ -71,13 +72,13 @@ func (c *Client) RecordAdd(domain, zone, recordType string, ttl int, overwrite b
 }
 
 // RecordGet retrieves records for a domain in a zone, optionally filtered by type.
-func (c *Client) RecordGet(domain, zone string) ([]Record, error) {
+func (c *Client) RecordGet(ctx context.Context, domain, zone string) ([]Record, error) {
 	qp := url.Values{
 		"domain": {domain},
 		"zone":   {zone},
 	}
 
-	resp, err := c.doGet("/api/zones/records/get", qp)
+	resp, err := c.doGet(ctx, "/api/zones/records/get", qp)
 	if err != nil {
 		return nil, fmt.Errorf("getting records for %q in zone %q: %w", domain, zone, err)
 	}
@@ -96,7 +97,7 @@ func (c *Client) RecordGet(domain, zone string) ([]Record, error) {
 // For CNAME: "cname" (new value)
 // For MX: "exchange" (current), "newExchange" (new), "preference", "newPreference"
 // etc.
-func (c *Client) RecordUpdate(domain, zone, recordType string, ttl int, params map[string]string) error {
+func (c *Client) RecordUpdate(ctx context.Context, domain, zone, recordType string, ttl int, params map[string]string) error {
 	qp := url.Values{
 		"domain": {domain},
 		"zone":   {zone},
@@ -109,7 +110,7 @@ func (c *Client) RecordUpdate(domain, zone, recordType string, ttl int, params m
 		qp.Set(k, v)
 	}
 
-	_, err := c.doGet("/api/zones/records/update", qp)
+	_, err := c.doGet(ctx, "/api/zones/records/update", qp)
 	if err != nil {
 		return fmt.Errorf("updating %s record for %q in zone %q: %w", recordType, domain, zone, err)
 	}
@@ -126,7 +127,7 @@ func (c *Client) RecordUpdate(domain, zone, recordType string, ttl int, params m
 //   - PTR: "ptrName"
 //   - NS: "nameServer"
 //   - CAA: "flags", "tag", "value"
-func (c *Client) RecordDelete(domain, zone, recordType string, params map[string]string) error {
+func (c *Client) RecordDelete(ctx context.Context, domain, zone, recordType string, params map[string]string) error {
 	qp := url.Values{
 		"domain": {domain},
 		"zone":   {zone},
@@ -136,7 +137,7 @@ func (c *Client) RecordDelete(domain, zone, recordType string, params map[string
 		qp.Set(k, v)
 	}
 
-	_, err := c.doGet("/api/zones/records/delete", qp)
+	_, err := c.doGet(ctx, "/api/zones/records/delete", qp)
 	if err != nil {
 		return fmt.Errorf("deleting %s record for %q in zone %q: %w", recordType, domain, zone, err)
 	}

--- a/internal/client/settings.go
+++ b/internal/client/settings.go
@@ -4,6 +4,7 @@
 package client
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/url"
@@ -60,8 +61,8 @@ type ServerSettings struct {
 }
 
 // SettingsGet returns the current server settings.
-func (c *Client) SettingsGet() (*ServerSettings, error) {
-	resp, err := c.doGet("/api/settings/get", nil)
+func (c *Client) SettingsGet(ctx context.Context) (*ServerSettings, error) {
+	resp, err := c.doGet(ctx, "/api/settings/get", nil)
 	if err != nil {
 		return nil, fmt.Errorf("getting server settings: %w", err)
 	}
@@ -75,13 +76,13 @@ func (c *Client) SettingsGet() (*ServerSettings, error) {
 }
 
 // SettingsSet updates server settings via POST.
-func (c *Client) SettingsSet(params map[string]string) error {
+func (c *Client) SettingsSet(ctx context.Context, params map[string]string) error {
 	qp := url.Values{}
 	for k, v := range params {
 		qp.Set(k, v)
 	}
 
-	_, err := c.doPost("/api/settings/set", qp)
+	_, err := c.doPost(ctx, "/api/settings/set", qp)
 	if err != nil {
 		return fmt.Errorf("updating server settings: %w", err)
 	}

--- a/internal/client/tsig.go
+++ b/internal/client/tsig.go
@@ -4,6 +4,7 @@
 package client
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"strings"
@@ -20,8 +21,8 @@ type TSIGKey struct {
 var ErrTSIGKeyNotFound = errors.New("TSIG key not found")
 
 // TSIGKeyList returns all TSIG keys from server settings.
-func (c *Client) TSIGKeyList() ([]TSIGKey, error) {
-	settings, err := c.SettingsGet()
+func (c *Client) TSIGKeyList(ctx context.Context) ([]TSIGKey, error) {
+	settings, err := c.SettingsGet(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("listing TSIG keys: %w", err)
 	}
@@ -32,8 +33,8 @@ func (c *Client) TSIGKeyList() ([]TSIGKey, error) {
 }
 
 // TSIGKeyGet returns a single TSIG key by name.
-func (c *Client) TSIGKeyGet(keyName string) (*TSIGKey, error) {
-	keys, err := c.TSIGKeyList()
+func (c *Client) TSIGKeyGet(ctx context.Context, keyName string) (*TSIGKey, error) {
+	keys, err := c.TSIGKeyList(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -49,7 +50,7 @@ func (c *Client) TSIGKeyGet(keyName string) (*TSIGKey, error) {
 // writeTSIGKeys encodes the key list as pipe-delimited and writes to settings.
 // Format: name1|secret1|algo1|name2|secret2|algo2
 // Empty list sends tsigKeys=false to clear all keys.
-func (c *Client) writeTSIGKeys(keys []TSIGKey) error {
+func (c *Client) writeTSIGKeys(ctx context.Context, keys []TSIGKey) error {
 	value := "false"
 	if len(keys) > 0 {
 		parts := make([]string, 0, len(keys)*3)
@@ -58,7 +59,7 @@ func (c *Client) writeTSIGKeys(keys []TSIGKey) error {
 		}
 		value = strings.Join(parts, "|")
 	}
-	return c.SettingsSet(map[string]string{"tsigKeys": value})
+	return c.SettingsSet(ctx, map[string]string{"tsigKeys": value})
 }
 
 // validateTSIGKeyFields checks that no field contains the pipe delimiter
@@ -73,12 +74,12 @@ func validateTSIGKeyFields(key TSIGKey) error {
 }
 
 // TSIGKeyCreate adds a new TSIG key. Returns error if key name already exists.
-func (c *Client) TSIGKeyCreate(key TSIGKey) error {
+func (c *Client) TSIGKeyCreate(ctx context.Context, key TSIGKey) error {
 	if err := validateTSIGKeyFields(key); err != nil {
 		return fmt.Errorf("creating TSIG key: %w", err)
 	}
 
-	keys, err := c.TSIGKeyList()
+	keys, err := c.TSIGKeyList(ctx)
 	if err != nil {
 		return fmt.Errorf("creating TSIG key: %w", err)
 	}
@@ -91,19 +92,19 @@ func (c *Client) TSIGKeyCreate(key TSIGKey) error {
 	}
 
 	keys = append(keys, key)
-	if err := c.writeTSIGKeys(keys); err != nil {
+	if err := c.writeTSIGKeys(ctx, keys); err != nil {
 		return fmt.Errorf("creating TSIG key %q: %w", key.KeyName, err)
 	}
 	return nil
 }
 
 // TSIGKeyUpdate replaces an existing TSIG key by name.
-func (c *Client) TSIGKeyUpdate(key TSIGKey) error {
+func (c *Client) TSIGKeyUpdate(ctx context.Context, key TSIGKey) error {
 	if err := validateTSIGKeyFields(key); err != nil {
 		return fmt.Errorf("updating TSIG key: %w", err)
 	}
 
-	keys, err := c.TSIGKeyList()
+	keys, err := c.TSIGKeyList(ctx)
 	if err != nil {
 		return fmt.Errorf("updating TSIG key: %w", err)
 	}
@@ -120,15 +121,15 @@ func (c *Client) TSIGKeyUpdate(key TSIGKey) error {
 		return ErrTSIGKeyNotFound
 	}
 
-	if err := c.writeTSIGKeys(keys); err != nil {
+	if err := c.writeTSIGKeys(ctx, keys); err != nil {
 		return fmt.Errorf("updating TSIG key %q: %w", key.KeyName, err)
 	}
 	return nil
 }
 
 // TSIGKeyDelete removes a TSIG key by name. Idempotent — succeeds silently if key not found.
-func (c *Client) TSIGKeyDelete(keyName string) error {
-	keys, err := c.TSIGKeyList()
+func (c *Client) TSIGKeyDelete(ctx context.Context, keyName string) error {
+	keys, err := c.TSIGKeyList(ctx)
 	if err != nil {
 		return fmt.Errorf("deleting TSIG key: %w", err)
 	}
@@ -145,7 +146,7 @@ func (c *Client) TSIGKeyDelete(keyName string) error {
 		return nil
 	}
 
-	if err := c.writeTSIGKeys(filtered); err != nil {
+	if err := c.writeTSIGKeys(ctx, filtered); err != nil {
 		return fmt.Errorf("deleting TSIG key %q: %w", keyName, err)
 	}
 	return nil

--- a/internal/client/zones.go
+++ b/internal/client/zones.go
@@ -4,6 +4,7 @@
 package client
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/url"
@@ -86,7 +87,7 @@ type DSInfo struct {
 }
 
 // ZoneCreate creates a new authoritative zone.
-func (c *Client) ZoneCreate(name, zoneType string, useSoaSerialDateScheme bool) (string, error) {
+func (c *Client) ZoneCreate(ctx context.Context, name, zoneType string, useSoaSerialDateScheme bool) (string, error) {
 	params := url.Values{
 		"zone": {name},
 		"type": {zoneType},
@@ -95,7 +96,7 @@ func (c *Client) ZoneCreate(name, zoneType string, useSoaSerialDateScheme bool) 
 		params.Set("useSoaSerialDateScheme", "true")
 	}
 
-	resp, err := c.doGet("/api/zones/create", params)
+	resp, err := c.doGet(ctx, "/api/zones/create", params)
 	if err != nil {
 		return "", fmt.Errorf("creating zone %q: %w", name, err)
 	}
@@ -111,11 +112,11 @@ func (c *Client) ZoneCreate(name, zoneType string, useSoaSerialDateScheme bool) 
 }
 
 // ZoneDelete deletes an authoritative zone.
-func (c *Client) ZoneDelete(name string) error {
+func (c *Client) ZoneDelete(ctx context.Context, name string) error {
 	params := url.Values{
 		"zone": {name},
 	}
-	_, err := c.doGet("/api/zones/delete", params)
+	_, err := c.doGet(ctx, "/api/zones/delete", params)
 	if err != nil {
 		return fmt.Errorf("deleting zone %q: %w", name, err)
 	}
@@ -123,8 +124,8 @@ func (c *Client) ZoneDelete(name string) error {
 }
 
 // ZoneList returns all authoritative zones.
-func (c *Client) ZoneList() ([]ZoneListItem, error) {
-	resp, err := c.doGet("/api/zones/list", nil)
+func (c *Client) ZoneList(ctx context.Context) ([]ZoneListItem, error) {
+	resp, err := c.doGet(ctx, "/api/zones/list", nil)
 	if err != nil {
 		return nil, fmt.Errorf("listing zones: %w", err)
 	}
@@ -140,11 +141,11 @@ func (c *Client) ZoneList() ([]ZoneListItem, error) {
 }
 
 // ZoneOptionsGet returns the zone-specific options.
-func (c *Client) ZoneOptionsGet(name string) (*Zone, error) {
+func (c *Client) ZoneOptionsGet(ctx context.Context, name string) (*Zone, error) {
 	params := url.Values{
 		"zone": {name},
 	}
-	resp, err := c.doGet("/api/zones/options/get", params)
+	resp, err := c.doGet(ctx, "/api/zones/options/get", params)
 	if err != nil {
 		return nil, fmt.Errorf("getting zone options for %q: %w", name, err)
 	}
@@ -158,7 +159,7 @@ func (c *Client) ZoneOptionsGet(name string) (*Zone, error) {
 }
 
 // ZoneOptionsSet updates zone-specific options.
-func (c *Client) ZoneOptionsSet(name string, opts map[string]string) error {
+func (c *Client) ZoneOptionsSet(ctx context.Context, name string, opts map[string]string) error {
 	params := url.Values{
 		"zone": {name},
 	}
@@ -166,7 +167,7 @@ func (c *Client) ZoneOptionsSet(name string, opts map[string]string) error {
 		params.Set(k, v)
 	}
 
-	_, err := c.doGet("/api/zones/options/set", params)
+	_, err := c.doGet(ctx, "/api/zones/options/set", params)
 	if err != nil {
 		return fmt.Errorf("setting zone options for %q: %w", name, err)
 	}
@@ -177,7 +178,7 @@ func (c *Client) ZoneOptionsSet(name string, opts map[string]string) error {
 // algorithm: RSA, ECDSA, EDDSA
 // curve: P256, P384 (ECDSA) or ED25519, ED448 (EDDSA)
 // nxProof: NSEC or NSEC3
-func (c *Client) ZoneDNSSECSign(name, algorithm, curve, nxProof string) error {
+func (c *Client) ZoneDNSSECSign(ctx context.Context, name, algorithm, curve, nxProof string) error {
 	params := url.Values{
 		"zone":      {name},
 		"algorithm": {algorithm},
@@ -194,7 +195,7 @@ func (c *Client) ZoneDNSSECSign(name, algorithm, curve, nxProof string) error {
 		params.Set("saltLength", "0")
 	}
 
-	_, err := c.doGet("/api/zones/dnssec/sign", params)
+	_, err := c.doGet(ctx, "/api/zones/dnssec/sign", params)
 	if err != nil {
 		return fmt.Errorf("signing zone %q with DNSSEC: %w", name, err)
 	}
@@ -202,11 +203,11 @@ func (c *Client) ZoneDNSSECSign(name, algorithm, curve, nxProof string) error {
 }
 
 // ZoneDNSSECUnsign removes DNSSEC from a zone.
-func (c *Client) ZoneDNSSECUnsign(name string) error {
+func (c *Client) ZoneDNSSECUnsign(ctx context.Context, name string) error {
 	params := url.Values{
 		"zone": {name},
 	}
-	_, err := c.doGet("/api/zones/dnssec/unsign", params)
+	_, err := c.doGet(ctx, "/api/zones/dnssec/unsign", params)
 	if err != nil {
 		return fmt.Errorf("unsigning zone %q: %w", name, err)
 	}
@@ -214,11 +215,11 @@ func (c *Client) ZoneDNSSECUnsign(name string) error {
 }
 
 // ZoneDNSSECPropertiesGet returns DNSSEC properties for a zone.
-func (c *Client) ZoneDNSSECPropertiesGet(name string) (*DNSSECProperties, error) {
+func (c *Client) ZoneDNSSECPropertiesGet(ctx context.Context, name string) (*DNSSECProperties, error) {
 	params := url.Values{
 		"zone": {name},
 	}
-	resp, err := c.doGet("/api/zones/dnssec/properties/get", params)
+	resp, err := c.doGet(ctx, "/api/zones/dnssec/properties/get", params)
 	if err != nil {
 		return nil, fmt.Errorf("getting DNSSEC properties for %q: %w", name, err)
 	}
@@ -232,11 +233,11 @@ func (c *Client) ZoneDNSSECPropertiesGet(name string) (*DNSSECProperties, error)
 }
 
 // ZoneDNSSECViewDS returns DS records for a signed zone.
-func (c *Client) ZoneDNSSECViewDS(name string) (*DSInfo, error) {
+func (c *Client) ZoneDNSSECViewDS(ctx context.Context, name string) (*DSInfo, error) {
 	params := url.Values{
 		"zone": {name},
 	}
-	resp, err := c.doGet("/api/zones/dnssec/viewDS", params)
+	resp, err := c.doGet(ctx, "/api/zones/dnssec/viewDS", params)
 	if err != nil {
 		return nil, fmt.Errorf("getting DS records for %q: %w", name, err)
 	}
@@ -250,8 +251,8 @@ func (c *Client) ZoneDNSSECViewDS(name string) (*DSInfo, error) {
 }
 
 // ZoneExists checks if a zone exists by name.
-func (c *Client) ZoneExists(name string) (bool, error) {
-	zones, err := c.ZoneList()
+func (c *Client) ZoneExists(ctx context.Context, name string) (bool, error) {
+	zones, err := c.ZoneList(ctx)
 	if err != nil {
 		return false, err
 	}

--- a/internal/provider/allowed_zone_data_source.go
+++ b/internal/provider/allowed_zone_data_source.go
@@ -66,7 +66,7 @@ func (d *AllowedZoneDataSource) Read(ctx context.Context, req datasource.ReadReq
 
 	domain := config.Domain.ValueString()
 
-	exists, err := readDomainExists(d.client, domain, FilterZoneAllowed)
+	exists, err := readDomainExists(ctx, d.client, domain, FilterZoneAllowed)
 	if err != nil {
 		resp.Diagnostics.AddError("Error reading allowed zone",
 			fmt.Sprintf("Could not check allowed zone %q: %s", domain, err.Error()))

--- a/internal/provider/allowed_zone_resource.go
+++ b/internal/provider/allowed_zone_resource.go
@@ -87,7 +87,7 @@ func (r *AllowedZoneResource) Create(ctx context.Context, req resource.CreateReq
 
 	domain := plan.Domain.ValueString()
 
-	if _, err := checkAndSetCreate(r.client, domain, FilterZoneAllowed); err != nil {
+	if _, err := checkAndSetCreate(ctx, r.client, domain, FilterZoneAllowed); err != nil {
 		resp.Diagnostics.AddError("Error creating allowed zone", err.Error())
 		return
 	}
@@ -107,7 +107,7 @@ func (r *AllowedZoneResource) Read(ctx context.Context, req resource.ReadRequest
 
 	domain := state.Domain.ValueString()
 
-	exists, err := readDomainExists(r.client, domain, FilterZoneAllowed)
+	exists, err := readDomainExists(ctx, r.client, domain, FilterZoneAllowed)
 	if err != nil {
 		resp.Diagnostics.AddError("Error reading allowed zone", err.Error())
 		return
@@ -136,7 +136,7 @@ func (r *AllowedZoneResource) Delete(ctx context.Context, req resource.DeleteReq
 		return
 	}
 
-	if err := checkAndSetDelete(r.client, state.Domain.ValueString(), FilterZoneAllowed); err != nil {
+	if err := checkAndSetDelete(ctx, r.client, state.Domain.ValueString(), FilterZoneAllowed); err != nil {
 		resp.Diagnostics.AddError("Error deleting allowed zone", err.Error())
 	}
 }

--- a/internal/provider/allowed_zone_resource_test.go
+++ b/internal/provider/allowed_zone_resource_test.go
@@ -4,6 +4,7 @@
 package provider
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"testing"
@@ -43,11 +44,11 @@ func TestAccAllowedZoneResource_checkAndSetAdopt(t *testing.T) {
 	c := testAccDirectClient(t)
 
 	// Pre-create the zone via direct API call so Terraform must adopt it
-	if err := c.AllowedZoneAdd(domain); err != nil {
+	if err := c.AllowedZoneAdd(context.Background(), domain); err != nil {
 		t.Fatalf("pre-create allowed zone: %v", err)
 	}
 	t.Cleanup(func() {
-		_ = c.AllowedZoneDelete(domain)
+		_ = c.AllowedZoneDelete(context.Background(), domain)
 	})
 
 	resource.Test(t, resource.TestCase{

--- a/internal/provider/allowed_zones_data_source.go
+++ b/internal/provider/allowed_zones_data_source.go
@@ -62,7 +62,7 @@ func (d *AllowedZonesDataSource) Read(ctx context.Context, req datasource.ReadRe
 		return
 	}
 
-	domains, err := zoneList(d.client, FilterZoneAllowed)
+	domains, err := zoneList(ctx, d.client, FilterZoneAllowed)
 	if err != nil {
 		resp.Diagnostics.AddError("Error listing allowed zones",
 			fmt.Sprintf("Could not retrieve allowed zone list: %s", err.Error()))

--- a/internal/provider/allowed_zones_resource.go
+++ b/internal/provider/allowed_zones_resource.go
@@ -87,7 +87,7 @@ func (r *AllowedZonesResource) Create(ctx context.Context, req resource.CreateRe
 	}
 
 	for _, d := range domains {
-		if _, err := checkAndSetCreate(r.client, d, FilterZoneAllowed); err != nil {
+		if _, err := checkAndSetCreate(ctx, r.client, d, FilterZoneAllowed); err != nil {
 			resp.Diagnostics.AddError("Error creating allowed zone", err.Error())
 			return
 		}
@@ -118,7 +118,7 @@ func (r *AllowedZonesResource) Read(ctx context.Context, req resource.ReadReques
 
 	var existing []string
 	for _, d := range stateDomains {
-		exists, err := readDomainExists(r.client, d, FilterZoneAllowed)
+		exists, err := readDomainExists(ctx, r.client, d, FilterZoneAllowed)
 		if err != nil {
 			resp.Diagnostics.AddError("Error reading allowed zone", err.Error())
 			return
@@ -168,7 +168,7 @@ func (r *AllowedZonesResource) Update(ctx context.Context, req resource.UpdateRe
 		return
 	}
 
-	if err := reconcileSet(r.client, stateDomains, planDomains, FilterZoneAllowed); err != nil {
+	if err := reconcileSet(ctx, r.client, stateDomains, planDomains, FilterZoneAllowed); err != nil {
 		resp.Diagnostics.AddError("Error updating allowed zones", err.Error())
 		return
 	}
@@ -192,7 +192,7 @@ func (r *AllowedZonesResource) Delete(ctx context.Context, req resource.DeleteRe
 	}
 
 	for _, d := range domains {
-		if err := checkAndSetDelete(r.client, d, FilterZoneAllowed); err != nil {
+		if err := checkAndSetDelete(ctx, r.client, d, FilterZoneAllowed); err != nil {
 			resp.Diagnostics.AddError("Error deleting allowed zone", err.Error())
 			return
 		}

--- a/internal/provider/allowed_zones_resource_test.go
+++ b/internal/provider/allowed_zones_resource_test.go
@@ -4,6 +4,7 @@
 package provider
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"strings"
@@ -85,12 +86,12 @@ func TestAccAllowedZonesResource_checkAndSetAdopt(t *testing.T) {
 	c := testAccDirectClient(t)
 
 	// Pre-create the domain so Terraform must adopt it.
-	if err := c.AllowedZoneAdd(adoptDomain); err != nil {
+	if err := c.AllowedZoneAdd(context.Background(), adoptDomain); err != nil {
 		t.Fatalf("pre-create allowed zone %q: %v", adoptDomain, err)
 	}
 	t.Cleanup(func() {
 		for _, d := range allDomains {
-			_ = c.AllowedZoneDelete(d)
+			_ = c.AllowedZoneDelete(context.Background(), d)
 		}
 	})
 

--- a/internal/provider/blocked_zone_data_source.go
+++ b/internal/provider/blocked_zone_data_source.go
@@ -65,7 +65,7 @@ func (d *BlockedZoneDataSource) Read(ctx context.Context, req datasource.ReadReq
 	}
 
 	domain := config.Domain.ValueString()
-	exists, err := readDomainExists(d.client, domain, FilterZoneBlocked)
+	exists, err := readDomainExists(ctx, d.client, domain, FilterZoneBlocked)
 	if err != nil {
 		resp.Diagnostics.AddError("Error checking blocked zone",
 			fmt.Sprintf("Could not check blocked zone %q: %s", domain, err.Error()))

--- a/internal/provider/blocked_zone_resource.go
+++ b/internal/provider/blocked_zone_resource.go
@@ -87,7 +87,7 @@ func (r *BlockedZoneResource) Create(ctx context.Context, req resource.CreateReq
 
 	domain := plan.Domain.ValueString()
 
-	if _, err := checkAndSetCreate(r.client, domain, FilterZoneBlocked); err != nil {
+	if _, err := checkAndSetCreate(ctx, r.client, domain, FilterZoneBlocked); err != nil {
 		resp.Diagnostics.AddError("Error creating blocked zone", err.Error())
 		return
 	}
@@ -105,7 +105,7 @@ func (r *BlockedZoneResource) Read(ctx context.Context, req resource.ReadRequest
 
 	domain := state.Domain.ValueString()
 
-	exists, err := readDomainExists(r.client, domain, FilterZoneBlocked)
+	exists, err := readDomainExists(ctx, r.client, domain, FilterZoneBlocked)
 	if err != nil {
 		resp.Diagnostics.AddError("Error reading blocked zone", err.Error())
 		return
@@ -133,7 +133,7 @@ func (r *BlockedZoneResource) Delete(ctx context.Context, req resource.DeleteReq
 		return
 	}
 
-	if err := checkAndSetDelete(r.client, state.Domain.ValueString(), FilterZoneBlocked); err != nil {
+	if err := checkAndSetDelete(ctx, r.client, state.Domain.ValueString(), FilterZoneBlocked); err != nil {
 		resp.Diagnostics.AddError("Error deleting blocked zone", err.Error())
 	}
 }

--- a/internal/provider/blocked_zone_resource_test.go
+++ b/internal/provider/blocked_zone_resource_test.go
@@ -4,6 +4,7 @@
 package provider
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"testing"
@@ -42,11 +43,11 @@ func TestAccBlockedZoneResource_checkAndSetAdopt(t *testing.T) {
 	c := testAccDirectClient(t)
 
 	// Clean up any stale entry then pre-create via direct API.
-	_ = c.BlockedZoneDelete(domain)
-	if err := c.BlockedZoneAdd(domain); err != nil {
+	_ = c.BlockedZoneDelete(context.Background(), domain)
+	if err := c.BlockedZoneAdd(context.Background(), domain); err != nil {
 		t.Fatalf("failed to pre-create blocked zone %q: %s", domain, err)
 	}
-	t.Cleanup(func() { _ = c.BlockedZoneDelete(domain) })
+	t.Cleanup(func() { _ = c.BlockedZoneDelete(context.Background(), domain) })
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,

--- a/internal/provider/blocked_zones_data_source.go
+++ b/internal/provider/blocked_zones_data_source.go
@@ -56,7 +56,7 @@ func (d *BlockedZonesDataSource) Configure(_ context.Context, req datasource.Con
 }
 
 func (d *BlockedZonesDataSource) Read(ctx context.Context, _ datasource.ReadRequest, resp *datasource.ReadResponse) {
-	domains, err := zoneList(d.client, FilterZoneBlocked)
+	domains, err := zoneList(ctx, d.client, FilterZoneBlocked)
 	if err != nil {
 		resp.Diagnostics.AddError("Error listing blocked zones", err.Error())
 		return

--- a/internal/provider/blocked_zones_resource.go
+++ b/internal/provider/blocked_zones_resource.go
@@ -87,7 +87,7 @@ func (r *BlockedZonesResource) Create(ctx context.Context, req resource.CreateRe
 	}
 
 	for _, d := range domains {
-		if _, err := checkAndSetCreate(r.client, d, FilterZoneBlocked); err != nil {
+		if _, err := checkAndSetCreate(ctx, r.client, d, FilterZoneBlocked); err != nil {
 			resp.Diagnostics.AddError("Error creating blocked zone", err.Error())
 			return
 		}
@@ -118,7 +118,7 @@ func (r *BlockedZonesResource) Read(ctx context.Context, req resource.ReadReques
 
 	var remaining []string
 	for _, d := range stateDomains {
-		exists, err := readDomainExists(r.client, d, FilterZoneBlocked)
+		exists, err := readDomainExists(ctx, r.client, d, FilterZoneBlocked)
 		if err != nil {
 			resp.Diagnostics.AddError("Error reading blocked zone", err.Error())
 			return
@@ -163,7 +163,7 @@ func (r *BlockedZonesResource) Update(ctx context.Context, req resource.UpdateRe
 		return
 	}
 
-	if err := reconcileSet(r.client, stateDomains, planDomains, FilterZoneBlocked); err != nil {
+	if err := reconcileSet(ctx, r.client, stateDomains, planDomains, FilterZoneBlocked); err != nil {
 		resp.Diagnostics.AddError("Error updating blocked zones", err.Error())
 		return
 	}
@@ -187,7 +187,7 @@ func (r *BlockedZonesResource) Delete(ctx context.Context, req resource.DeleteRe
 	}
 
 	for _, d := range domains {
-		if err := checkAndSetDelete(r.client, d, FilterZoneBlocked); err != nil {
+		if err := checkAndSetDelete(ctx, r.client, d, FilterZoneBlocked); err != nil {
 			resp.Diagnostics.AddError("Error deleting blocked zone", err.Error())
 			return
 		}

--- a/internal/provider/blocked_zones_resource_test.go
+++ b/internal/provider/blocked_zones_resource_test.go
@@ -4,6 +4,7 @@
 package provider
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"strings"
@@ -88,13 +89,13 @@ func TestAccBlockedZonesResource_checkAndSetAdopt(t *testing.T) {
 	c := testAccDirectClient(t)
 
 	// Clean up any stale entry then pre-create via direct API.
-	_ = c.BlockedZoneDelete(adoptDomain)
-	if err := c.BlockedZoneAdd(adoptDomain); err != nil {
+	_ = c.BlockedZoneDelete(context.Background(), adoptDomain)
+	if err := c.BlockedZoneAdd(context.Background(), adoptDomain); err != nil {
 		t.Fatalf("failed to pre-create blocked zone %q: %s", adoptDomain, err)
 	}
 	t.Cleanup(func() {
-		_ = c.BlockedZoneDelete(adoptDomain)
-		_ = c.BlockedZoneDelete("acc-bz-adopt2.example.com")
+		_ = c.BlockedZoneDelete(context.Background(), adoptDomain)
+		_ = c.BlockedZoneDelete(context.Background(), "acc-bz-adopt2.example.com")
 	})
 
 	resource.Test(t, resource.TestCase{

--- a/internal/provider/blocking_common.go
+++ b/internal/provider/blocking_common.go
@@ -4,6 +4,7 @@
 package provider
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/darkhonor/terraform-provider-technitium/internal/client"
@@ -23,48 +24,48 @@ const (
 // ---------------------------------------------------------------------------
 
 // zoneExists returns true if domain is present in the named filter list.
-func zoneExists(c *client.Client, domain string, zoneType FilterZoneType) (bool, error) {
+func zoneExists(ctx context.Context, c *client.Client, domain string, zoneType FilterZoneType) (bool, error) {
 	switch zoneType {
 	case FilterZoneBlocked:
-		return c.BlockedZoneExists(domain)
+		return c.BlockedZoneExists(ctx, domain)
 	case FilterZoneAllowed:
-		return c.AllowedZoneExists(domain)
+		return c.AllowedZoneExists(ctx, domain)
 	default:
 		return false, fmt.Errorf("unknown filter zone type: %q", zoneType)
 	}
 }
 
 // zoneAdd adds domain to the named filter list.
-func zoneAdd(c *client.Client, domain string, zoneType FilterZoneType) error {
+func zoneAdd(ctx context.Context, c *client.Client, domain string, zoneType FilterZoneType) error {
 	switch zoneType {
 	case FilterZoneBlocked:
-		return c.BlockedZoneAdd(domain)
+		return c.BlockedZoneAdd(ctx, domain)
 	case FilterZoneAllowed:
-		return c.AllowedZoneAdd(domain)
+		return c.AllowedZoneAdd(ctx, domain)
 	default:
 		return fmt.Errorf("unknown filter zone type: %q", zoneType)
 	}
 }
 
 // zoneDelete removes domain from the named filter list.
-func zoneDelete(c *client.Client, domain string, zoneType FilterZoneType) error {
+func zoneDelete(ctx context.Context, c *client.Client, domain string, zoneType FilterZoneType) error {
 	switch zoneType {
 	case FilterZoneBlocked:
-		return c.BlockedZoneDelete(domain)
+		return c.BlockedZoneDelete(ctx, domain)
 	case FilterZoneAllowed:
-		return c.AllowedZoneDelete(domain)
+		return c.AllowedZoneDelete(ctx, domain)
 	default:
 		return fmt.Errorf("unknown filter zone type: %q", zoneType)
 	}
 }
 
 // zoneList returns all domains in the named filter list.
-func zoneList(c *client.Client, zoneType FilterZoneType) ([]string, error) {
+func zoneList(ctx context.Context, c *client.Client, zoneType FilterZoneType) ([]string, error) {
 	switch zoneType {
 	case FilterZoneBlocked:
-		return c.BlockedZoneList()
+		return c.BlockedZoneList(ctx)
 	case FilterZoneAllowed:
-		return c.AllowedZoneList()
+		return c.AllowedZoneList(ctx)
 	default:
 		return nil, fmt.Errorf("unknown filter zone type: %q", zoneType)
 	}
@@ -77,15 +78,15 @@ func zoneList(c *client.Client, zoneType FilterZoneType) ([]string, error) {
 // checkAndSetCreate ensures domain is present in the named filter list.
 // If the domain already exists it is adopted (adopted=true) without error.
 // If the domain does not exist it is added (adopted=false).
-func checkAndSetCreate(c *client.Client, domain string, zoneType FilterZoneType) (adopted bool, err error) {
-	exists, err := zoneExists(c, domain, zoneType)
+func checkAndSetCreate(ctx context.Context, c *client.Client, domain string, zoneType FilterZoneType) (adopted bool, err error) {
+	exists, err := zoneExists(ctx, c, domain, zoneType)
 	if err != nil {
 		return false, fmt.Errorf("checking %s zone %q before create: %w", zoneType, domain, err)
 	}
 	if exists {
 		return true, nil
 	}
-	if err := zoneAdd(c, domain, zoneType); err != nil {
+	if err := zoneAdd(ctx, c, domain, zoneType); err != nil {
 		return false, fmt.Errorf("adding %s zone %q: %w", zoneType, domain, err)
 	}
 	return false, nil
@@ -93,15 +94,15 @@ func checkAndSetCreate(c *client.Client, domain string, zoneType FilterZoneType)
 
 // checkAndSetDelete removes domain from the named filter list if it exists.
 // A missing domain is treated as a no-op (idempotent).
-func checkAndSetDelete(c *client.Client, domain string, zoneType FilterZoneType) error {
-	exists, err := zoneExists(c, domain, zoneType)
+func checkAndSetDelete(ctx context.Context, c *client.Client, domain string, zoneType FilterZoneType) error {
+	exists, err := zoneExists(ctx, c, domain, zoneType)
 	if err != nil {
 		return fmt.Errorf("checking %s zone %q before delete: %w", zoneType, domain, err)
 	}
 	if !exists {
 		return nil
 	}
-	if err := zoneDelete(c, domain, zoneType); err != nil {
+	if err := zoneDelete(ctx, c, domain, zoneType); err != nil {
 		return fmt.Errorf("deleting %s zone %q: %w", zoneType, domain, err)
 	}
 	return nil
@@ -111,7 +112,7 @@ func checkAndSetDelete(c *client.Client, domain string, zoneType FilterZoneType)
 // from the set of domains recorded in state (stateDomains). Domains present in
 // the plan but absent from state are added; domains present in state but absent
 // from the plan are removed.
-func reconcileSet(c *client.Client, stateDomains, planDomains []string, zoneType FilterZoneType) error {
+func reconcileSet(ctx context.Context, c *client.Client, stateDomains, planDomains []string, zoneType FilterZoneType) error {
 	stateMap := make(map[string]struct{}, len(stateDomains))
 	for _, d := range stateDomains {
 		stateMap[d] = struct{}{}
@@ -125,7 +126,7 @@ func reconcileSet(c *client.Client, stateDomains, planDomains []string, zoneType
 	// Add domains that are in the plan but not in state.
 	for d := range planMap {
 		if _, inState := stateMap[d]; !inState {
-			if _, err := checkAndSetCreate(c, d, zoneType); err != nil {
+			if _, err := checkAndSetCreate(ctx, c, d, zoneType); err != nil {
 				return err
 			}
 		}
@@ -134,7 +135,7 @@ func reconcileSet(c *client.Client, stateDomains, planDomains []string, zoneType
 	// Remove domains that are in state but not in the plan.
 	for d := range stateMap {
 		if _, inPlan := planMap[d]; !inPlan {
-			if err := checkAndSetDelete(c, d, zoneType); err != nil {
+			if err := checkAndSetDelete(ctx, c, d, zoneType); err != nil {
 				return err
 			}
 		}
@@ -144,6 +145,6 @@ func reconcileSet(c *client.Client, stateDomains, planDomains []string, zoneType
 }
 
 // readDomainExists is a pure existence check for use during Read operations.
-func readDomainExists(c *client.Client, domain string, zoneType FilterZoneType) (bool, error) {
-	return zoneExists(c, domain, zoneType)
+func readDomainExists(ctx context.Context, c *client.Client, domain string, zoneType FilterZoneType) (bool, error) {
+	return zoneExists(ctx, c, domain, zoneType)
 }

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -344,7 +344,7 @@ func (p *TechnitiumProvider) Configure(ctx context.Context, req provider.Configu
 	}
 
 	// Verify connectivity with tiered TLS error diagnostics
-	if err := apiClient.Ping(); err != nil {
+	if err := apiClient.Ping(ctx); err != nil {
 		isHTTPS := strings.HasPrefix(serverURL, "https://")
 		if isHTTPS {
 			tlsErr := client.ClassifyTLSError(err)

--- a/internal/provider/record_data_source.go
+++ b/internal/provider/record_data_source.go
@@ -110,7 +110,7 @@ func (d *RecordDataSource) Read(ctx context.Context, req datasource.ReadRequest,
 		return
 	}
 
-	records, err := d.client.RecordGet(config.Name.ValueString(), config.Zone.ValueString())
+	records, err := d.client.RecordGet(ctx, config.Name.ValueString(), config.Zone.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Error reading records", err.Error())
 		return

--- a/internal/provider/record_resource.go
+++ b/internal/provider/record_resource.go
@@ -180,7 +180,7 @@ func (r *RecordResource) Create(ctx context.Context, req resource.CreateRequest,
 	}
 
 	params := r.buildAddParams(&plan)
-	record, err := r.client.RecordAdd(
+	record, err := r.client.RecordAdd(ctx,
 		plan.Name.ValueString(),
 		plan.Zone.ValueString(),
 		plan.Type.ValueString(),
@@ -206,7 +206,7 @@ func (r *RecordResource) Read(ctx context.Context, req resource.ReadRequest, res
 		return
 	}
 
-	records, err := r.client.RecordGet(state.Name.ValueString(), state.Zone.ValueString())
+	records, err := r.client.RecordGet(ctx, state.Name.ValueString(), state.Zone.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Error reading record", err.Error())
 		return
@@ -265,7 +265,7 @@ func (r *RecordResource) Update(ctx context.Context, req resource.UpdateRequest,
 	}
 
 	params := r.buildUpdateParams(&state, &plan)
-	err := r.client.RecordUpdate(
+	err := r.client.RecordUpdate(ctx,
 		plan.Name.ValueString(),
 		plan.Zone.ValueString(),
 		plan.Type.ValueString(),
@@ -278,7 +278,7 @@ func (r *RecordResource) Update(ctx context.Context, req resource.UpdateRequest,
 	}
 
 	// Read back
-	records, err := r.client.RecordGet(plan.Name.ValueString(), plan.Zone.ValueString())
+	records, err := r.client.RecordGet(ctx, plan.Name.ValueString(), plan.Zone.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Error reading record after update", err.Error())
 		return
@@ -295,15 +295,15 @@ func (r *RecordResource) Update(ctx context.Context, req resource.UpdateRequest,
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 }
 
-func (r *RecordResource) Delete(_ context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+func (r *RecordResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
 	var state RecordResourceModel
-	resp.Diagnostics.Append(req.State.Get(context.Background(), &state)...)
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
 	params := r.buildDeleteParams(&state)
-	err := r.client.RecordDelete(
+	err := r.client.RecordDelete(ctx,
 		state.Name.ValueString(),
 		state.Zone.ValueString(),
 		state.Type.ValueString(),

--- a/internal/provider/server_settings_data_source.go
+++ b/internal/provider/server_settings_data_source.go
@@ -102,7 +102,7 @@ func (d *ServerSettingsDataSource) Configure(_ context.Context, req datasource.C
 }
 
 func (d *ServerSettingsDataSource) Read(ctx context.Context, _ datasource.ReadRequest, resp *datasource.ReadResponse) {
-	settings, err := d.client.SettingsGet()
+	settings, err := d.client.SettingsGet(ctx)
 	if err != nil {
 		resp.Diagnostics.AddError("Error reading server settings", err.Error())
 		return

--- a/internal/provider/server_settings_resource.go
+++ b/internal/provider/server_settings_resource.go
@@ -302,7 +302,7 @@ func (r *ServerSettingsResource) Create(ctx context.Context, req resource.Create
 	// Apply settings
 	params := r.buildParams(ctx, &plan)
 	if len(params) > 0 {
-		if err := r.client.SettingsSet(params); err != nil {
+		if err := r.client.SettingsSet(ctx, params); err != nil {
 			resp.Diagnostics.AddError("Error setting server settings", err.Error())
 			return
 		}
@@ -341,7 +341,7 @@ func (r *ServerSettingsResource) Update(ctx context.Context, req resource.Update
 
 	params := r.buildParams(ctx, &plan)
 	if len(params) > 0 {
-		if err := r.client.SettingsSet(params); err != nil {
+		if err := r.client.SettingsSet(ctx, params); err != nil {
 			resp.Diagnostics.AddError("Error updating server settings", err.Error())
 			return
 		}
@@ -401,7 +401,7 @@ func (r *ServerSettingsResource) buildParams(ctx context.Context, model *ServerS
 
 // readState reads current settings from the API into the model.
 func (r *ServerSettingsResource) readState(ctx context.Context, model *ServerSettingsResourceModel) error {
-	settings, err := r.client.SettingsGet()
+	settings, err := r.client.SettingsGet(ctx)
 	if err != nil {
 		return err
 	}

--- a/internal/provider/tsig_key_data_source.go
+++ b/internal/provider/tsig_key_data_source.go
@@ -66,7 +66,7 @@ func (d *TSIGKeyDataSource) Read(ctx context.Context, req datasource.ReadRequest
 		return
 	}
 
-	key, err := d.client.TSIGKeyGet(config.KeyName.ValueString())
+	key, err := d.client.TSIGKeyGet(ctx, config.KeyName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Error reading TSIG key",
 			fmt.Sprintf("Could not find TSIG key %q: %s", config.KeyName.ValueString(), err.Error()))

--- a/internal/provider/tsig_key_resource.go
+++ b/internal/provider/tsig_key_resource.go
@@ -167,13 +167,13 @@ func (r *TSIGKeyResource) Create(ctx context.Context, req resource.CreateRequest
 		SharedSecret:  plan.SharedSecret.ValueString(),
 	}
 
-	if err := r.client.TSIGKeyCreate(key); err != nil {
+	if err := r.client.TSIGKeyCreate(ctx, key); err != nil {
 		resp.Diagnostics.AddError("Error creating TSIG key", err.Error())
 		return
 	}
 
 	// Read back state from the API
-	created, err := r.client.TSIGKeyGet(plan.KeyName.ValueString())
+	created, err := r.client.TSIGKeyGet(ctx, plan.KeyName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Error reading TSIG key after create", err.Error())
 		return
@@ -194,7 +194,7 @@ func (r *TSIGKeyResource) Read(ctx context.Context, req resource.ReadRequest, re
 		return
 	}
 
-	key, err := r.client.TSIGKeyGet(state.KeyName.ValueString())
+	key, err := r.client.TSIGKeyGet(ctx, state.KeyName.ValueString())
 	if err != nil {
 		if errors.Is(err, client.ErrTSIGKeyNotFound) {
 			resp.State.RemoveResource(ctx)
@@ -225,13 +225,13 @@ func (r *TSIGKeyResource) Update(ctx context.Context, req resource.UpdateRequest
 		SharedSecret:  plan.SharedSecret.ValueString(),
 	}
 
-	if err := r.client.TSIGKeyUpdate(key); err != nil {
+	if err := r.client.TSIGKeyUpdate(ctx, key); err != nil {
 		resp.Diagnostics.AddError("Error updating TSIG key", err.Error())
 		return
 	}
 
 	// Read back state
-	updated, err := r.client.TSIGKeyGet(plan.KeyName.ValueString())
+	updated, err := r.client.TSIGKeyGet(ctx, plan.KeyName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Error reading TSIG key after update", err.Error())
 		return
@@ -252,7 +252,7 @@ func (r *TSIGKeyResource) Delete(ctx context.Context, req resource.DeleteRequest
 		return
 	}
 
-	if err := r.client.TSIGKeyDelete(state.KeyName.ValueString()); err != nil {
+	if err := r.client.TSIGKeyDelete(ctx, state.KeyName.ValueString()); err != nil {
 		resp.Diagnostics.AddError("Error deleting TSIG key", err.Error())
 	}
 }

--- a/internal/provider/zone_data_source.go
+++ b/internal/provider/zone_data_source.go
@@ -118,7 +118,7 @@ func (d *ZoneDataSource) Read(ctx context.Context, req datasource.ReadRequest, r
 	zoneName := config.Name.ValueString()
 
 	// Get zone options
-	zone, err := d.client.ZoneOptionsGet(zoneName)
+	zone, err := d.client.ZoneOptionsGet(ctx, zoneName)
 	if err != nil {
 		resp.Diagnostics.AddError("Error reading zone",
 			fmt.Sprintf("Could not read zone %q: %s", zoneName, err.Error()))
@@ -144,7 +144,7 @@ func (d *ZoneDataSource) Read(ctx context.Context, req datasource.ReadRequest, r
 	config.NotifyNameServers = notifyNS
 
 	// Get SOA serial from zone list
-	zones, err := d.client.ZoneList()
+	zones, err := d.client.ZoneList(ctx)
 	if err != nil {
 		resp.Diagnostics.AddError("Error listing zones", err.Error())
 		return

--- a/internal/provider/zone_resource.go
+++ b/internal/provider/zone_resource.go
@@ -274,7 +274,7 @@ func (r *ZoneResource) Create(ctx context.Context, req resource.CreateRequest, r
 	}
 
 	// Create zone
-	domain, err := r.client.ZoneCreate(
+	domain, err := r.client.ZoneCreate(ctx,
 		plan.Name.ValueString(),
 		plan.Type.ValueString(),
 		plan.SOASerialDateScheme.ValueBool(),
@@ -294,7 +294,7 @@ func (r *ZoneResource) Create(ctx context.Context, req resource.CreateRequest, r
 
 	// Handle DNSSEC signing (NSS P256→P384 upgrade already handled in ModifyPlan)
 	if plan.DNSSEC != nil && plan.DNSSEC.Enabled.ValueBool() && plan.Type.ValueString() == "Primary" {
-		err := r.client.ZoneDNSSECSign(
+		err := r.client.ZoneDNSSECSign(ctx,
 			plan.Name.ValueString(),
 			plan.DNSSEC.Algorithm.ValueString(),
 			plan.DNSSEC.Curve.ValueString(),
@@ -323,7 +323,7 @@ func (r *ZoneResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 	}
 
 	// Check if zone still exists
-	exists, err := r.client.ZoneExists(state.Name.ValueString())
+	exists, err := r.client.ZoneExists(ctx, state.Name.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Error checking zone existence", err.Error())
 		return
@@ -369,7 +369,7 @@ func (r *ZoneResource) Update(ctx context.Context, req resource.UpdateRequest, r
 
 		if planDNSSECEnabled && !stateDNSSECEnabled {
 			// Sign zone
-			err := r.client.ZoneDNSSECSign(
+			err := r.client.ZoneDNSSECSign(ctx,
 				plan.Name.ValueString(),
 				plan.DNSSEC.Algorithm.ValueString(),
 				plan.DNSSEC.Curve.ValueString(),
@@ -381,7 +381,7 @@ func (r *ZoneResource) Update(ctx context.Context, req resource.UpdateRequest, r
 			}
 		} else if !planDNSSECEnabled && stateDNSSECEnabled {
 			// Unsign zone
-			if err := r.client.ZoneDNSSECUnsign(plan.Name.ValueString()); err != nil {
+			if err := r.client.ZoneDNSSECUnsign(ctx, plan.Name.ValueString()); err != nil {
 				resp.Diagnostics.AddError("Error unsigning zone", err.Error())
 				return
 			}
@@ -397,14 +397,14 @@ func (r *ZoneResource) Update(ctx context.Context, req resource.UpdateRequest, r
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 }
 
-func (r *ZoneResource) Delete(_ context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+func (r *ZoneResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
 	var state ZoneResourceModel
-	resp.Diagnostics.Append(req.State.Get(context.Background(), &state)...)
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	if err := r.client.ZoneDelete(state.Name.ValueString()); err != nil {
+	if err := r.client.ZoneDelete(ctx, state.Name.ValueString()); err != nil {
 		resp.Diagnostics.AddError("Error deleting zone", err.Error())
 	}
 }
@@ -463,14 +463,14 @@ func (r *ZoneResource) setZoneOptions(ctx context.Context, plan *ZoneResourceMod
 	}
 
 	if len(opts) > 0 {
-		return r.client.ZoneOptionsSet(plan.Name.ValueString(), opts)
+		return r.client.ZoneOptionsSet(ctx, plan.Name.ValueString(), opts)
 	}
 	return nil
 }
 
 // readZoneState reads the current zone state from the API.
 func (r *ZoneResource) readZoneState(ctx context.Context, model *ZoneResourceModel) error {
-	zone, err := r.client.ZoneOptionsGet(model.Name.ValueString())
+	zone, err := r.client.ZoneOptionsGet(ctx, model.Name.ValueString())
 	if err != nil {
 		return fmt.Errorf("reading zone options: %w", err)
 	}
@@ -521,7 +521,7 @@ func (r *ZoneResource) readZoneState(ctx context.Context, model *ZoneResourceMod
 	}
 
 	// Read SOA serial from zone list
-	zones, err := r.client.ZoneList()
+	zones, err := r.client.ZoneList(ctx)
 	if err != nil {
 		return fmt.Errorf("listing zones for SOA serial: %w", err)
 	}
@@ -534,7 +534,7 @@ func (r *ZoneResource) readZoneState(ctx context.Context, model *ZoneResourceMod
 
 	// Read DNSSEC state
 	if zone.DNSSECStatus != "Unsigned" && zone.DNSSECStatus != "" {
-		props, err := r.client.ZoneDNSSECPropertiesGet(model.Name.ValueString())
+		props, err := r.client.ZoneDNSSECPropertiesGet(ctx, model.Name.ValueString())
 		if err != nil {
 			return fmt.Errorf("reading DNSSEC properties: %w", err)
 		}
@@ -567,8 +567,8 @@ func (r *ZoneResource) readZoneState(ctx context.Context, model *ZoneResourceMod
 
 // validateTsigKeyReference checks that a TSIG key exists and, in NSS mode,
 // that its algorithm meets FIPS 140-3 / CNSSI 1253 requirements.
-func (r *ZoneResource) validateTsigKeyReference(keyName string, diagnostics *diag.Diagnostics) {
-	key, err := r.client.TSIGKeyGet(keyName)
+func (r *ZoneResource) validateTsigKeyReference(ctx context.Context, keyName string, diagnostics *diag.Diagnostics) {
+	key, err := r.client.TSIGKeyGet(ctx, keyName)
 	if err != nil {
 		if errors.Is(err, client.ErrTSIGKeyNotFound) {
 			diagnostics.AddError(
@@ -599,7 +599,7 @@ func (r *ZoneResource) validateTsigKeyReferences(ctx context.Context, plan *Zone
 		var keyNames []string
 		plan.ZoneTransferTsigKeyNames.ElementsAs(ctx, &keyNames, false)
 		for _, keyName := range keyNames {
-			r.validateTsigKeyReference(keyName, diagnostics)
+			r.validateTsigKeyReference(ctx, keyName, diagnostics)
 		}
 	}
 
@@ -607,7 +607,7 @@ func (r *ZoneResource) validateTsigKeyReferences(ctx context.Context, plan *Zone
 	if !plan.PrimaryZoneTransferTsigKeyName.IsNull() && !plan.PrimaryZoneTransferTsigKeyName.IsUnknown() {
 		keyName := plan.PrimaryZoneTransferTsigKeyName.ValueString()
 		if keyName != "" {
-			r.validateTsigKeyReference(keyName, diagnostics)
+			r.validateTsigKeyReference(ctx, keyName, diagnostics)
 		}
 	}
 }

--- a/internal/provider/zone_resource_test.go
+++ b/internal/provider/zone_resource_test.go
@@ -4,6 +4,7 @@
 package provider
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"regexp"
@@ -576,12 +577,12 @@ func TestAccZoneResource_NSS_TsigKeyCompliant_sha512(t *testing.T) {
 func TestAccZoneResource_NSS_TsigKeyNonCompliant_md5(t *testing.T) {
 	c := testAccDirectClient(t)
 	keyName := "acc-nss-zk-md5.example.com"
-	_ = c.TSIGKeyDelete(keyName) // best-effort cleanup of stale key from prior runs
-	if err := c.TSIGKeyCreate(client.TSIGKey{KeyName: keyName, AlgorithmName: "hmac-md5.sig-alg.reg.int"}); err != nil {
+	_ = c.TSIGKeyDelete(context.Background(), keyName) // best-effort cleanup of stale key from prior runs
+	if err := c.TSIGKeyCreate(context.Background(), client.TSIGKey{KeyName: keyName, AlgorithmName: "hmac-md5.sig-alg.reg.int"}); err != nil {
 		t.Fatalf("failed to pre-create TSIG key: %s", err)
 	}
 	t.Cleanup(func() {
-		if err := c.TSIGKeyDelete(keyName); err != nil {
+		if err := c.TSIGKeyDelete(context.Background(), keyName); err != nil {
 			t.Logf("cleanup: failed to delete TSIG key %s: %v", keyName, err)
 		}
 	})
@@ -600,12 +601,12 @@ func TestAccZoneResource_NSS_TsigKeyNonCompliant_md5(t *testing.T) {
 func TestAccZoneResource_NSS_TsigKeyNonCompliant_sha1(t *testing.T) {
 	c := testAccDirectClient(t)
 	keyName := "acc-nss-zk-sha1.example.com"
-	_ = c.TSIGKeyDelete(keyName) // best-effort cleanup of stale key from prior runs
-	if err := c.TSIGKeyCreate(client.TSIGKey{KeyName: keyName, AlgorithmName: "hmac-sha1"}); err != nil {
+	_ = c.TSIGKeyDelete(context.Background(), keyName) // best-effort cleanup of stale key from prior runs
+	if err := c.TSIGKeyCreate(context.Background(), client.TSIGKey{KeyName: keyName, AlgorithmName: "hmac-sha1"}); err != nil {
 		t.Fatalf("failed to pre-create TSIG key: %s", err)
 	}
 	t.Cleanup(func() {
-		if err := c.TSIGKeyDelete(keyName); err != nil {
+		if err := c.TSIGKeyDelete(context.Background(), keyName); err != nil {
 			t.Logf("cleanup: failed to delete TSIG key %s: %v", keyName, err)
 		}
 	})
@@ -624,12 +625,12 @@ func TestAccZoneResource_NSS_TsigKeyNonCompliant_sha1(t *testing.T) {
 func TestAccZoneResource_NSS_TsigKeyNonCompliant_sha256_128(t *testing.T) {
 	c := testAccDirectClient(t)
 	keyName := "acc-nss-zk-sha256-128.example.com"
-	_ = c.TSIGKeyDelete(keyName) // best-effort cleanup of stale key from prior runs
-	if err := c.TSIGKeyCreate(client.TSIGKey{KeyName: keyName, AlgorithmName: "hmac-sha256-128"}); err != nil {
+	_ = c.TSIGKeyDelete(context.Background(), keyName) // best-effort cleanup of stale key from prior runs
+	if err := c.TSIGKeyCreate(context.Background(), client.TSIGKey{KeyName: keyName, AlgorithmName: "hmac-sha256-128"}); err != nil {
 		t.Fatalf("failed to pre-create TSIG key: %s", err)
 	}
 	t.Cleanup(func() {
-		if err := c.TSIGKeyDelete(keyName); err != nil {
+		if err := c.TSIGKeyDelete(context.Background(), keyName); err != nil {
 			t.Logf("cleanup: failed to delete TSIG key %s: %v", keyName, err)
 		}
 	})
@@ -648,12 +649,12 @@ func TestAccZoneResource_NSS_TsigKeyNonCompliant_sha256_128(t *testing.T) {
 func TestAccZoneResource_NSS_TsigKeyNonCompliant_sha384_192(t *testing.T) {
 	c := testAccDirectClient(t)
 	keyName := "acc-nss-zk-sha384-192.example.com"
-	_ = c.TSIGKeyDelete(keyName) // best-effort cleanup of stale key from prior runs
-	if err := c.TSIGKeyCreate(client.TSIGKey{KeyName: keyName, AlgorithmName: "hmac-sha384-192"}); err != nil {
+	_ = c.TSIGKeyDelete(context.Background(), keyName) // best-effort cleanup of stale key from prior runs
+	if err := c.TSIGKeyCreate(context.Background(), client.TSIGKey{KeyName: keyName, AlgorithmName: "hmac-sha384-192"}); err != nil {
 		t.Fatalf("failed to pre-create TSIG key: %s", err)
 	}
 	t.Cleanup(func() {
-		if err := c.TSIGKeyDelete(keyName); err != nil {
+		if err := c.TSIGKeyDelete(context.Background(), keyName); err != nil {
 			t.Logf("cleanup: failed to delete TSIG key %s: %v", keyName, err)
 		}
 	})
@@ -672,12 +673,12 @@ func TestAccZoneResource_NSS_TsigKeyNonCompliant_sha384_192(t *testing.T) {
 func TestAccZoneResource_NSS_TsigKeyNonCompliant_sha512_256(t *testing.T) {
 	c := testAccDirectClient(t)
 	keyName := "acc-nss-zk-sha512-256.example.com"
-	_ = c.TSIGKeyDelete(keyName) // best-effort cleanup of stale key from prior runs
-	if err := c.TSIGKeyCreate(client.TSIGKey{KeyName: keyName, AlgorithmName: "hmac-sha512-256"}); err != nil {
+	_ = c.TSIGKeyDelete(context.Background(), keyName) // best-effort cleanup of stale key from prior runs
+	if err := c.TSIGKeyCreate(context.Background(), client.TSIGKey{KeyName: keyName, AlgorithmName: "hmac-sha512-256"}); err != nil {
 		t.Fatalf("failed to pre-create TSIG key: %s", err)
 	}
 	t.Cleanup(func() {
-		if err := c.TSIGKeyDelete(keyName); err != nil {
+		if err := c.TSIGKeyDelete(context.Background(), keyName); err != nil {
 			t.Logf("cleanup: failed to delete TSIG key %s: %v", keyName, err)
 		}
 	})


### PR DESCRIPTION
## Summary

Threads `context.Context` from Terraform CRUD handlers through the client layer to all HTTP calls, replacing `http.Client.Get`/`PostForm` with `http.NewRequestWithContext` + `http.Client.Do`.

Fixes #21

### What this enables

- **Request cancellation** when users interrupt `terraform plan`/`apply` (Ctrl+C)
- **Timeout propagation** from the Terraform Plugin Framework
- **Proper context lifecycle** per NIST SP800-53 SC-10 (Network Disconnect)

### Changes

| Layer | Files | Change |
|-------|-------|--------|
| Client core | `client.go` | `doGet`/`doPost`/`Ping` accept `ctx`, use `NewRequestWithContext` |
| Client methods | `records.go`, `zones.go`, `tsig.go`, `blocked.go`, `allowed.go`, `settings.go` | All public methods accept `ctx`, pass to `doGet`/`doPost` |
| Provider resources | 12 resource/data source files | Pass existing `ctx` from CRUD handlers to client calls |
| Provider helpers | `blocking_common.go` | Thread `ctx` through routing helpers |
| Tests | 4 test files | Pass `context.Background()` to client calls |
| Linter | `.golangci.yml` | Enable `noctx` linter |

32 files changed, +224 -194 lines. Purely mechanical — no logic changes.

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `golangci-lint run ./...` — 0 issues (with `noctx` enabled)
- [x] Client unit tests — 34/34 pass
- [x] Provider unit tests — 21/21 pass


🤖 Generated with [Claude Code](https://claude.com/claude-code)