### PR TITLE
test(infra): run Technitium test container as non-root host user (closes #36)

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,5 +1,32 @@
 default: build
 
+# Container runs as the host user (UID/GID resolved at runtime) so that
+# bind-mounted test material is read/writable without root or chown
+# gymnastics. Defaults match the typical Linux user; CI runners (e.g.
+# GitHub Actions UID 1001) will pick up their own UID via these exports.
+# See docker-compose.test.yml and issue #36.
+export HOST_UID := $(shell id -u)
+export HOST_GID := $(shell id -g)
+
+# Preflight: if ./.testdata (or anything beneath it that we use as a bind
+# mount source) exists but contains paths not writable by the current
+# user, it is almost certainly leftover from a pre-#36 root-container
+# test run. Fail with a clear remediation instead of letting the
+# downstream `mkdir -p` or container startup fail in a less obvious way.
+# The recursive find catches the case where ./.testdata itself is fine
+# but ./.testdata/dns-data/<subpath> has root-owned files.
+.PHONY: _testdata-preflight
+_testdata-preflight:
+	@if [ -e ./.testdata ] && find ./.testdata -not -writable -print -quit 2>/dev/null | grep -q .; then \
+		echo "ERROR: ./.testdata contains paths not writable by UID $$(id -u)."; \
+		echo "This usually means stale root-owned files from an older root-container test run."; \
+		echo "Offending path(s):"; \
+		find ./.testdata -not -writable -print 2>/dev/null | sed 's/^/  /'; \
+		echo "Remove all with (no sudo needed):"; \
+		echo "  docker run --rm -v \"\$$(pwd):/wipe\" alpine:latest rm -rf /wipe/.testdata"; \
+		exit 1; \
+	fi
+
 build:
 	go build -v ./...
 
@@ -25,14 +52,19 @@ testacc-token:
 	sed -i'' -e "s/^TECHNITIUM_API_TOKEN=.*/TECHNITIUM_API_TOKEN=$$API_TOKEN/" .env.test && \
 	echo "Token provisioned and written to .env.test"
 
-testacc-up:
+testacc-up: _testdata-preflight
 	@test -f .env.test || (echo "ERROR: .env.test not found. Copy .env.test.example to .env.test and fill in values." && exit 1)
+	mkdir -p ./.testdata/dns-data
 	docker compose -f docker-compose.test.yml up -d --wait
 	$(MAKE) testacc-token
 	$(MAKE) testacc
 
 testacc-down:
 	docker compose -f docker-compose.test.yml down -v
+	# Same cleanup rationale as testacc-down-tls (issue #36): non-root
+	# container means host user owns the bind-mounted data dir, so plain
+	# rm works.
+	rm -rf ./.testdata/dns-data
 
 # --- TLS-enabled acceptance test path -----------------------------------------
 #
@@ -67,8 +99,9 @@ testacc-tls:
 	 TF_ACC=1 \
 	 go test -v ./... -count=1 -timeout 120m
 
-testacc-up-tls:
+testacc-up-tls: _testdata-preflight
 	$(MAKE) testacc-tls-prep
+	mkdir -p ./.testdata/dns-data
 	docker compose -f docker-compose.test.yml -f docker-compose.test.tls.yml up -d --wait
 	@echo "Waiting for HTTPS admin endpoint to accept requests..."
 	@PW=$$( (test -f .env.test && grep -E '^DNS_ADMIN_PASSWORD=' .env.test | cut -d= -f2) || echo admin ); \
@@ -86,16 +119,12 @@ testacc-up-tls:
 	$(MAKE) testacc-tls
 
 testacc-down-tls:
+	# .testdata/dns-data is a host bind mount of the Technitium data dir; the
+	# container runs as the host user (issue #36), so files written there are
+	# host-owned and removable without sudo. ./testdata/tls is the generated
+	# TLS material. Both are wiped here for a clean next-run baseline.
 	docker compose -f docker-compose.test.yml -f docker-compose.test.tls.yml down -v
-	# .testdata/config is a bind mount, not a docker volume, so `down -v`
-	# does not clear it. Files inside it are owned by root (because the
-	# Technitium container runs as root — see issue #36), so a host-side
-	# `rm -rf` would need sudo. Use a throwaway container to wipe it
-	# instead, which avoids any host privilege requirement.
-	@if [ -d ./.testdata/config ]; then \
-		docker run --rm -v "$$(pwd)/.testdata:/wipe" alpine:latest rm -rf /wipe/config; \
-	fi
-	rm -rf ./testdata/tls
+	rm -rf ./.testdata/dns-data ./testdata/tls
 
 generate:
 	go generate ./...
@@ -115,4 +144,4 @@ generate-stig:
 	go run ./tools/generate_stig_baselines.go
 	@echo "Generated internal/provider/validators/stig_baselines_gen.go"
 
-.PHONY: build build-fips test test-fips testacc testacc-token testacc-up testacc-down testacc-tls-prep testacc-token-tls testacc-tls testacc-up-tls testacc-down-tls generate docs lint install generate-stig
+.PHONY: build build-fips test test-fips testacc testacc-token testacc-up testacc-down testacc-tls-prep testacc-token-tls testacc-tls testacc-up-tls testacc-down-tls generate docs lint install generate-stig _testdata-preflight

--- a/README.md
+++ b/README.md
@@ -210,16 +210,19 @@ acceptance test. The container stays running so you can iterate. Tear it down wh
 make testacc-down
 ```
 
-> **Note:** Acceptance tests require a running Technitium DNS Server instance. The included
-> Docker Compose file provides a pre-configured test environment:
+> **Note:** Acceptance tests require a running Technitium DNS Server instance. The
+> `make testacc-up` target handles the full lifecycle: runs a preflight ownership
+> check on `./.testdata/`, creates the bind-mount data directory with host-user
+> ownership, starts the container as a non-root user (per issue #36), provisions a
+> fresh API token, and runs every acceptance test. Unit tests (`make test`) do not
+> require Docker and run entirely offline.
 >
-> ```bash
-> docker compose -f docker-compose.test.yml up -d
-> ```
->
-> The `make testacc-up` target handles the full lifecycle: starts the container, provisions a
-> fresh API token, and runs every acceptance test. Unit tests (`make test`) do not require
-> Docker and run entirely offline.
+> Invoking `docker compose -f docker-compose.test.yml up -d` directly is **not
+> supported**. The compose file's `user:` directive expects `HOST_UID` and
+> `HOST_GID` environment variables exported by the make target, and the bind-mount
+> source directory must exist with the host user's ownership before container
+> start. Bypassing `make` will silently fall back to `1000:1000` and may produce
+> permission errors on any host where the user's UID/GID differs.
 
 #### TLS-mode acceptance suite
 

--- a/docker-compose.test.tls.yml
+++ b/docker-compose.test.tls.yml
@@ -9,6 +9,24 @@
 # After this overlay, the admin API is reachable at https://127.0.0.1:5443
 # with the CA at ./testdata/tls/ca.pem (used by the provider via
 # TECHNITIUM_CACERT).
+#
+# Inherited from docker-compose.test.yml via compose merge semantics
+# (NOT redeclared here):
+#   - user: "${HOST_UID:-1000}:${HOST_GID:-1000}"  (scalar; base wins)
+#   - cap_add: [NET_BIND_SERVICE]                  (list-append; base entry kept)
+#   - tmpfs: [/var/log/technitium:size=128m]       (list-append; base entry kept)
+#   - volumes: ./.testdata/dns-data:/etc/dns       (list-append; the overlay's
+#                                                  ./testdata/tls:/etc/dns/tls:ro
+#                                                  mount nests inside it, shadowing
+#                                                  the /etc/dns/tls subpath with the
+#                                                  read-only host bind)
+#   - env_file: [.env.test]                        (list-append; base entry kept,
+#                                                  values still apply to the merged
+#                                                  service)
+#   - environment: (overlay's environment map ADDS/OVERRIDES specific keys; it does
+#                  NOT replace the env_file source — both apply in the merged
+#                  service, with overlay environment values winning on key conflict)
+# See issue #36 and docker-compose.test.yml for the non-root container rationale.
 
 services:
   technitium:

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,7 +1,32 @@
+# This compose file is designed to be invoked via the GNUmakefile's
+# testacc-up / testacc-up-tls targets, which export HOST_UID and HOST_GID
+# (resolved from `id`) so the `user:` directive below runs the container
+# as the host user. Direct `docker compose -f docker-compose.test.yml up`
+# outside of make will silently fall back to the 1000:1000 defaults and
+# may produce bind-mount permission errors on any host where the user's
+# UID/GID is not 1000. The supported entrypoint is `make testacc-up{,-tls}`.
+
 services:
   technitium:
     image: technitium/dns-server:latest@sha256:99c250f0ee494f2f31e09a76d83f8213bc4c5d6f106b0895cd5f327518469c48
     container_name: technitium-test
+    # Run as the host user so bind-mounted test material is owned correctly
+    # without chown or relaxed file modes. Defaults to 1000:1000 (typical
+    # Linux user); the GNUmakefile exports HOST_UID/HOST_GID resolved from
+    # `id` so CI runners (e.g. GitHub Actions UID 1001) pick up their own
+    # UID. See issue #36.
+    user: "${HOST_UID:-1000}:${HOST_GID:-1000}"
+    # NET_BIND_SERVICE is declared defensively. Under current Docker
+    # (Engine 20.10+) containers default to
+    # net.ipv4.ip_unprivileged_port_start=0, which means non-root
+    # processes can already bind low ports without this capability — so
+    # the cap_add is redundant today. It is kept explicit so the test
+    # fixture survives future Docker default tightening (e.g. rootless
+    # Docker, Podman, or hardened daemon configs) where the unprivileged
+    # port range is restricted. The container still binds port 53
+    # internally (host port 15353 maps to container port 53).
+    cap_add:
+      - NET_BIND_SERVICE
     ports:
       - "127.0.0.1:5380:5380"
       - "127.0.0.1:15353:53/udp"
@@ -9,4 +34,20 @@ services:
     env_file:
       - .env.test
     volumes:
-      - ./.testdata/config:/etc/dns/config
+      # Bind-mount the WHOLE /etc/dns dir (not just /etc/dns/config) so the
+      # non-root container can create subpaths like /etc/dns/blocklists at
+      # startup. The image ships with /etc/dns empty, so a fresh
+      # host-side dir is sufficient. The host dir is created by the
+      # GNUmakefile `mkdir -p` step, which inherits the host user's
+      # ownership — matching the container UID set above means writes
+      # work without chown gymnastics. A Docker-managed named volume was
+      # tried first but initializes with the image's root ownership,
+      # blocking the non-root container.
+      - ./.testdata/dns-data:/etc/dns
+    tmpfs:
+      # /var/log/technitium is the image's default log dir; root-owned in
+      # the image and unwritable by the non-root container. tmpfs is ideal
+      # for ephemeral test logs: writable by the container UID, no host
+      # pollution, automatic cleanup on container stop. Capped at 128m so a
+      # runaway log loop can't fill memory.
+      - /var/log/technitium:size=128m


### PR DESCRIPTION
## Summary

Closes the non-root half of issue #36. Part A (image digest pin) was already landed via merged Renovate PR #43; this PR fixes the "container runs as root" half by running the test container as the invoking host user.

Container UID/GID resolves to `${HOST_UID:-1000}:${HOST_GID:-1000}`, exported by the GNUmakefile via `id -u` / `id -g`. This matches the host user's ownership on bind-mounted material, so no chown gymnastics or mode relaxation is needed. CI runners (e.g. GitHub Actions UID 1001) pick up their own UID through the same exports.

## Design notes

The Technitium upstream image runs as root by default (verified via `docker inspect`) with no documented PUID/PGID or rootless variant. Upstream's `docker-compose.yml` assumes root. Their docs are silent on non-root operation. We do this cold by leveraging Docker's `user:` directive plus two mount-strategy choices:

1. **Bind-mount the WHOLE `/etc/dns`** (not just the `/etc/dns/config` subdir) at `./.testdata/dns-data:/etc/dns`. The host dir is created via `mkdir -p` in the makefile, inheriting host-user ownership — which matches the container UID. Image's `/etc/dns` is verified empty, so the bind shadows nothing functional.

2. **tmpfs at `/var/log/technitium`** for the log dir (the second image-owned dir Technitium writes to at startup) — ephemeral, container-UID-writable, no host pollution, 128 MiB cap.

The commit message documents the 3-iteration journey (subdir bind → named volume → whole-dir bind + tmpfs) and the empirical verification of each. Worth reading if you ever need to revisit this design.

## Codex pre-push review

Two rounds, 0 criticals each, 7 should-fix items total — all addressed:

| Round | Finding | Fix in this PR |
|---|---|---|
| 1 | `testacc-down` didn't clean dns-data symmetrically with `testacc-down-tls` | Added matching `rm -rf` |
| 1 | `mkdir -p` doesn't catch stale root-owned dir | New `_testdata-preflight` target with clear remediation message |
| 1 | Direct `docker compose` silent UID fallback | Doc block at top of compose file naming `make` as the supported entrypoint |
| 1 | `CAP_NET_BIND_SERVICE` may be redundant under current Docker defaults | Empirically verified redundant (`ip_unprivileged_port_start=0`); comment now frames cap as defensive against future Docker tightening |
| 2 | Preflight only checked top-level dir, missed nested root-owned files | Switched to recursive `find -not -writable` |
| 2 | README still advertised direct `docker compose up` (contradicted compose comment) | Replaced with explicit "use `make testacc-up`" framing and rationale |
| 2 | Overlay inheritance doc missing env_file and environment merging | Added both to the inheritance block |

## Side benefits

- `testacc-down-tls` no longer needs the throwaway-alpine-container teardown trick that issue #36 specifically called out as ugly. Plain `rm -rf` works.
- Local `go test ./...` no longer requires a sudo step to clean `.testdata` between manual runs.

## One-time migration

Existing developers / CI with stale root-owned `./.testdata/` from prior root-container runs will hit the new `_testdata-preflight` error. The error message tells them how to wipe it without sudo:

```
docker run --rm -v "$(pwd):/wipe" alpine:latest rm -rf /wipe/.testdata
```

## Verification

| Gate | Result |
|---|---|
| `_testdata-preflight` on clean tree | silent (correct) |
| `make testacc-up-tls` end-to-end | exit 0, container "running" healthcheck OK, HTTPS admin endpoint up |
| Full Go acceptance suite under non-root | `internal/provider` 56.30s, 0 failures |
| All `TestAccZoneResource_NSS_TsigKeyNonCompliant_*` tests | PASS |
| `make testacc-down-tls` | cleanly tears down, no sudo needed |
| `go build ./...` | clean |
| `go vet ./...` | clean |

## Files changed

- `docker-compose.test.yml`: `user`, `cap_add`, /etc/dns bind, /var/log/technitium tmpfs (+43 / -1)
- `docker-compose.test.tls.yml`: doc-only block listing inherited fields (+18 / -0)
- `GNUmakefile`: HOST_UID/GID exports, `_testdata-preflight` target, mkdir steps, symmetric `.down` cleanup (+53 / -13)
- `README.md`: removed unsupported direct-compose advertisement; replaced with explicit "use `make testacc-up`" guidance (+12 / -9)

Part of milestone [v1.2.0 - Catalog membership + Security hardening](https://github.com/darkhonor/terraform-provider-technitium/milestone/1).

Closes #36.

🤖 Generated with [Claude Code](https://claude.com/claude-code)