### PR TITLE
security(ci): enforce GitHub Actions SHA pinning

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -31,8 +31,24 @@ This security policy covers:
 - The Terraform provider binary and its source code
 - The STIG compliance validation engine
 - Credential handling (API tokens, TSIG keys)
+- GitHub Actions workflow integrity
 
 This policy does **not** cover:
 
 - The Technitium DNS Server itself (report to [TechnitiumSoftware](https://github.com/TechnitiumSoftware/DnsServer))
 - HashiCorp Terraform core (report to [HashiCorp](https://www.hashicorp.com/security))
+
+## GitHub Actions Pinning Policy
+
+All GitHub Actions `uses:` references must be pinned to a full 40-character
+commit SHA. Human-readable versions may be kept only as trailing comments, for
+example:
+
+```yaml
+- uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+```
+
+Do not pin actions by mutable tags such as `@v1`, `@v4`, or `@main`.
+Dependabot/Renovate manages SHA bumps for the `github_actions` ecosystem; the
+CI pinning gate prevents future workflow changes from weakening this
+supply-chain control.

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -27,12 +27,12 @@ jobs:
           go-version: "1.26"
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4
+        uses: github/codeql-action/init@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4.35.5
         with:
           languages: go
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4
+        uses: github/codeql-action/autobuild@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4.35.5
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4
+        uses: github/codeql-action/analyze@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4.35.5

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - name: Fetch Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/pin-actions.yml
+++ b/.github/workflows/pin-actions.yml
@@ -1,0 +1,31 @@
+name: Pin GitHub Actions
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    name: Verify action SHA pins
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+          persist-credentials: false
+
+      # Security ratchet for issue #56: every GitHub Actions uses reference
+      # must be pinned to a full 40-character commit SHA. pinact-action itself
+      # is also SHA-pinned so the enforcement tool does not become the new
+      # mutable supply-chain dependency.
+      - name: Verify GitHub Actions are SHA-pinned
+        uses: suzuki-shunsuke/pinact-action@cf51507d80d4d6522a07348e3d58790290eaf0b6 # v2.0.0
+        with:
+          skip_push: "true"
+          verify: "true"
+          github_token: ${{ github.token }}


### PR DESCRIPTION
## Summary

- Add a dedicated CI workflow that verifies every GitHub Actions `uses:` reference is pinned to a full 40-character commit SHA.
- Use `suzuki-shunsuke/pinact-action` in validate-only mode (`skip_push: "true"`, `verify: "true"`).
- Pin the pinact enforcement action itself by full commit SHA so the gate does not introduce a new mutable workflow dependency.
- Normalize existing Renovate-shortened action comments (`# v4`, `# v3`) to exact versions so pinact annotation verification passes.
- Document the SHA-pinning policy in `.github/SECURITY.md`.

Closes #56.

## Verification

- Static audit: all workflow `uses:` lines match full 40-character SHA pins.
- `git diff --check`
- First CI run proved the new gate works by failing on stale action version comments; branch updated to fix those comments and pass `github.token` to pinact for cross-repo annotation verification.
- Second CI run exposed a checkout merge-ref fetch failure in the new workflow; branch updated to checkout the PR head SHA directly with `persist-credentials: false`.

Local caveat:
- Hobibot still cannot reliably run new Go-module-backed tooling in Docker because module downloads stall from inside Docker. The PR is pushed so GitHub Actions can execute the authoritative pinact gate.
