### PR TITLE
fix(security): eliminate credential argv/env exposure in test harness (closes #35)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - New `Client.ZoneSetCatalog(ctx, zone, catalog)` API client helper. Passing
   an empty catalog string unsets membership.
 
+### Security
+
+- Acceptance-test token provisioning no longer exposes the Technitium admin
+  password or per-run API session token via `/proc/PID/cmdline` (`ps -ef`) or
+  `/proc/PID/environ` (`ps eww`). The `testacc-token`, `testacc-token-tls`,
+  and `testacc-up-tls` readiness-probe recipes were rewritten to pipe the
+  password to a new `scripts/test-token-bootstrap.sh` helper on stdin. The
+  helper reads the credential from stdin into a local shell variable,
+  URL-encodes it via a python helper that also reads from stdin, and sends
+  the form body to curl via `--data @-` on a bash heredoc. The password
+  value therefore never enters argv or env of any process in the test
+  harness flow. No production code or wire shape changes. ([#35])
+
 ### Known limitations
 
 - The three Technitium per-member catalog override flags
@@ -34,6 +47,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#23]: https://github.com/darkhonor/terraform-provider-technitium/issues/23
 [#29]: https://github.com/darkhonor/terraform-provider-technitium/issues/29
 [#30]: https://github.com/darkhonor/terraform-provider-technitium/issues/30
+[#35]: https://github.com/darkhonor/terraform-provider-technitium/issues/35
 
 ## [1.1.0] - 2026-03-29
 

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -40,15 +40,33 @@ test-fips:
 	GOEXPERIMENT=boringcrypto go test -v ./... -count=1
 
 testacc:
-	@test -f .env.test && export $$(grep -v '^#' .env.test | xargs) || true; \
+	@# Allow-list export from .env.test: each line is parsed individually
+	@# and the key is regex-validated as ^TECHNITIUM_[A-Z0-9_]+$$. Lines
+	@# whose KEY does not pass are skipped entirely. This is stricter than
+	@# the previous `grep ... | xargs` approach, which could be subverted
+	@# by a line like "TECHNITIUM_FOO=x DNS_ADMIN_PASSWORD=y" -- xargs
+	@# would split it into two separate VAR=VAL pairs and export both.
+	@# Secrets like DNS_ADMIN_PASSWORD are needed only by token bootstrap
+	@# and never enter the long-running `go test` environment (issue #35).
+	@set +x; \
+	if [ -f .env.test ]; then \
+		while IFS='=' read -r _k _v; do \
+			case "$$_k" in ''|\#*) continue ;; esac; \
+			if printf '%s' "$$_k" | grep -qE '^TECHNITIUM_[A-Z0-9_]+$$'; then \
+				export "$$_k=$$_v"; \
+			fi; \
+		done < .env.test; \
+	fi; \
 	TF_ACC=1 go test -v ./... -count=1 -timeout 120m
 
 testacc-token:
 	@echo "Provisioning fresh Technitium API token..."
-	@TOKEN=$$(curl -sf "http://127.0.0.1:5380/api/user/login?user=admin&pass=admin" | \
-		python3 -c "import sys,json; print(json.load(sys.stdin)['token'])" 2>/dev/null) && \
-	API_TOKEN=$$(curl -sf "http://127.0.0.1:5380/api/user/createToken?user=admin&pass=admin&tokenName=terraform-test-$$(date +%s)&token=$$TOKEN" | \
-		python3 -c "import sys,json; print(json.load(sys.stdin)['token'])" 2>/dev/null) && \
+	@set +x; \
+	PW=$$( (test -f .env.test && grep -E '^DNS_ADMIN_PASSWORD=' .env.test | cut -d= -f2-) || echo admin ); \
+	test -n "$$PW" || (echo "ERROR: DNS_ADMIN_PASSWORD is empty in .env.test"; exit 1); \
+	API_TOKEN=$$(printf '%s\n' "$$PW" | ./scripts/test-token-bootstrap.sh get-token \
+		http://127.0.0.1:5380 terraform-test-$$(date +%s)) && \
+	test -n "$$API_TOKEN" || (echo "ERROR: bootstrap returned empty API token"; exit 1) && \
 	sed -i'' -e "s/^TECHNITIUM_API_TOKEN=.*/TECHNITIUM_API_TOKEN=$$API_TOKEN/" .env.test && \
 	echo "Token provisioned and written to .env.test"
 
@@ -82,13 +100,13 @@ testacc-tls-prep:
 
 testacc-token-tls:
 	@echo "Provisioning fresh Technitium API token over HTTPS..."
-	@PW=$$( (test -f .env.test && grep -E '^DNS_ADMIN_PASSWORD=' .env.test | cut -d= -f2) || echo admin ); \
+	@set +x; \
+	PW=$$( (test -f .env.test && grep -E '^DNS_ADMIN_PASSWORD=' .env.test | cut -d= -f2-) || echo admin ); \
 	test -n "$$PW" || (echo "ERROR: DNS_ADMIN_PASSWORD is empty in .env.test"; exit 1); \
-	TOKEN=$$(curl -sf --cacert ./testdata/tls/ca.pem "https://127.0.0.1:5443/api/user/login?user=admin&pass=$$PW" | \
-		python3 -c "import sys,json; print(json.load(sys.stdin)['token'])" 2>/dev/null) && \
-	API_TOKEN=$$(curl -sf --cacert ./testdata/tls/ca.pem "https://127.0.0.1:5443/api/user/createToken?user=admin&pass=$$PW&tokenName=terraform-test-tls-$$(date +%s)&token=$$TOKEN" | \
-		python3 -c "import sys,json; print(json.load(sys.stdin)['token'])" 2>/dev/null) && \
-	(umask 077 && echo "$$API_TOKEN" > ./testdata/tls/api-token) && \
+	API_TOKEN=$$(printf '%s\n' "$$PW" | ./scripts/test-token-bootstrap.sh get-token \
+		https://127.0.0.1:5443 terraform-test-tls-$$(date +%s) ./testdata/tls/ca.pem) && \
+	test -n "$$API_TOKEN" || (echo "ERROR: bootstrap returned empty API token"; exit 1) && \
+	(umask 077 && printf '%s\n' "$$API_TOKEN" > ./testdata/tls/api-token) && \
 	echo "Token written to ./testdata/tls/api-token (mode 0600)"
 
 testacc-tls:
@@ -104,17 +122,10 @@ testacc-up-tls: _testdata-preflight
 	mkdir -p ./.testdata/dns-data
 	docker compose -f docker-compose.test.yml -f docker-compose.test.tls.yml up -d --wait
 	@echo "Waiting for HTTPS admin endpoint to accept requests..."
-	@PW=$$( (test -f .env.test && grep -E '^DNS_ADMIN_PASSWORD=' .env.test | cut -d= -f2) || echo admin ); \
-	for i in $$(seq 1 60); do \
-		if curl -sf --cacert ./testdata/tls/ca.pem --max-time 2 \
-		    "https://127.0.0.1:5443/api/user/login?user=admin&pass=$$PW" >/dev/null 2>&1; then \
-			echo "HTTPS endpoint ready after $$i attempt(s)"; break; \
-		fi; \
-		if [ $$i -eq 60 ]; then \
-			echo "ERROR: HTTPS endpoint never became ready (60 attempts, ~60s)"; exit 1; \
-		fi; \
-		sleep 1; \
-	done
+	@set +x; \
+	PW=$$( (test -f .env.test && grep -E '^DNS_ADMIN_PASSWORD=' .env.test | cut -d= -f2-) || echo admin ); \
+	printf '%s\n' "$$PW" | ./scripts/test-token-bootstrap.sh wait-ready \
+		https://127.0.0.1:5443 ./testdata/tls/ca.pem
 	$(MAKE) testacc-token-tls
 	$(MAKE) testacc-tls
 

--- a/README.md
+++ b/README.md
@@ -252,11 +252,15 @@ the NSS-mode and STIG-strict test families that cannot run under HTTP at all.
 The TLS target sources `DNS_ADMIN_PASSWORD` from `.env.test` (falling back to `admin` to
 match `.env.test.example`). It does not require any production credential.
 
-> **Known limitation:** the make targets currently pass the admin password and per-run API
-> token to `curl` as URL query parameters, which exposes them in local process listings
-> while curl is running. This is a side channel and is being tracked in
-> [#35](https://github.com/darkhonor/terraform-provider-technitium/issues/35); fix is to
-> move the credentials into the request body or a curl config file.
+> **Credential handling:** the make targets read `DNS_ADMIN_PASSWORD` from `.env.test`
+> into a shell variable and pipe it to `scripts/test-token-bootstrap.sh` on stdin via a
+> shell-builtin `printf`. The script reads the password from stdin into a local shell
+> variable, never sees it via argv or env, URL-encodes it through a python helper that
+> also reads from stdin, and sends the form body to curl via `--data @-` on a bash
+> heredoc. The credential value therefore does not appear in `/proc/PID/cmdline`
+> (`ps -ef`) or `/proc/PID/environ` (`ps eww`) of any process spawned during token
+> provisioning. Resolved in v1.2.0
+> ([#35](https://github.com/darkhonor/terraform-provider-technitium/issues/35)).
 
 CI runs `testacc-up-tls` automatically on every pull request.
 

--- a/scripts/test-token-bootstrap.sh
+++ b/scripts/test-token-bootstrap.sh
@@ -1,0 +1,267 @@
+#!/usr/bin/env bash
+#
+# Disable any inherited xtrace BEFORE secret handling so credentials are
+# never written to a debug-trace stream. Restore later modes via the
+# explicit `set -euo pipefail` below.
+set +x
+#
+# test-token-bootstrap.sh
+#
+# Provision Technitium API tokens for acceptance tests without exposing
+# admin credentials in any process's argv or environment (issue #35).
+#
+# Threat model (matches issue #35):
+#   * /proc/PID/cmdline (visible to all local users via `ps -ef`).
+#   * /proc/PID/environ (same-UID visible via `ps eww` or /proc reads).
+#
+# Strategy: the admin password is delivered to this script on its own
+# stdin (fd 0), NOT via argv and NOT via env. The script reads exactly
+# one line from stdin into a local shell variable, then immediately
+# closes/replaces fd 0 so the heredocs feeding curl below cannot
+# accidentally re-read it. The password value never appears in:
+#   * any process's argv  (it is never an argument anywhere)
+#   * any process's env   (it is never exported anywhere)
+#   * any explicit temp file (no temp files are created by this script)
+# It exists only in the script's own memory and in the body bytes sent
+# over the curl stdin pipe to the Technitium API.
+#
+# Caller contract (typically a Makefile recipe):
+#
+#   printf '%s\n' "$ADMIN_PASSWORD" | ./scripts/test-token-bootstrap.sh \
+#       get-token URL TOKEN_NAME [CACERT]
+#
+#   printf '%s\n' "$ADMIN_PASSWORD" | ./scripts/test-token-bootstrap.sh \
+#       wait-ready URL [CACERT]
+#
+# `printf` is a shell builtin in bash and dash; it does not fork an
+# external process, so the password never enters any argv on the caller
+# side either.
+#
+# Subcommands:
+#   wait-ready URL [CACERT]            -- poll login endpoint until ready
+#   get-token  URL TOKEN_NAME [CACERT] -- create + emit fresh API token
+#
+# All credentials and tokens are written to stdout only when explicitly
+# emitted by get-token. All progress messages go to stderr.
+
+set -euo pipefail
+
+usage() {
+    cat >&2 <<'USAGE'
+Usage:
+  printf '%s\n' "$PASSWORD" | test-token-bootstrap.sh wait-ready URL [CACERT]
+  printf '%s\n' "$PASSWORD" | test-token-bootstrap.sh get-token  URL TOKEN_NAME [CACERT]
+
+The admin password MUST be supplied on stdin as a single line terminated
+by LF (\n). The trailing newline is required: `read -r` returns non-zero
+on EOF without a delimiter, and `set -e` will abort the script. A
+trailing CR (CRLF input, e.g. Windows-edited .env.test) is stripped
+defensively. The password is never read from argv or env -- this is the
+entire point of the script per issue #35.
+
+Optional env (read-only, used only if set):
+  DNS_ADMIN_USER       admin username (default: admin). Not sensitive.
+
+wait-ready:
+  Polls URL/api/user/login via POST form body up to 60 times (1s each).
+  Exits 0 on first success, 1 on timeout. Progress on stderr.
+
+get-token:
+  Logs in to URL/api/user/login, then calls URL/api/user/createToken to
+  mint a fresh API token labeled TOKEN_NAME. Prints the API token (and
+  only the API token) to stdout. Diagnostics on stderr.
+USAGE
+    exit 2
+}
+
+# Read exactly one line of password material from fd 0 and assign it to
+# the caller-supplied variable name (via `printf -v`, which is portable
+# back to bash 3.2 -- macOS default). The value never appears in argv
+# (bash builtin `read` does not fork) and never in env (we never export
+# it). A trailing \r from CRLF input is stripped defensively so
+# Windows-edited .env.test files still work. After this call, fd 0 is
+# intentionally redirected from /dev/null so subsequent heredocs feeding
+# curl cannot accidentally pick up trailing stdin content.
+read_password_stdin() {
+    local _target="$1"
+    local _tmp
+    if ! IFS= read -r _tmp <&0; then
+        echo "ERROR: failed to read password from stdin -- caller must pipe a single LF-terminated line" >&2
+        return 1
+    fi
+    _tmp="${_tmp%$'\r'}"
+    printf -v "$_target" '%s' "$_tmp"
+    unset _tmp
+    exec 0</dev/null
+}
+
+# URL-percent-encode a value read from stdin and print to stdout.
+# Using stdin (rather than env or argv) keeps the raw value out of every
+# inspectable process surface.
+url_encode_stdin() {
+    python3 -c '
+import sys, urllib.parse
+print(urllib.parse.quote(sys.stdin.read(), safe=""), end="")
+'
+}
+
+# POST a form body (read from stdin) to $1 with optional --cacert $2.
+# Body lines arrive via `--data @-` so they live on the stdin pipe,
+# never in curl's argv.
+post_form() {
+    local url="$1"
+    local cacert="${2:-}"
+    local -a args=(--silent --fail --show-error --max-time 5 --data @-)
+    if [[ -n "$cacert" ]]; then
+        args+=(--cacert "$cacert")
+    fi
+    curl "${args[@]}" "$url"
+}
+
+# Extract the "token" field from a Technitium JSON response on stdin.
+# On error, prints ONLY the top-level keys and the type of the "status"
+# field, never `errorMessage` / `error` text or the value of any payload
+# field -- some API error bodies echo request parameters and could leak
+# credential material into CI logs.
+extract_token_field() {
+    python3 -c '
+import json, sys
+try:
+    payload = json.load(sys.stdin)
+except json.JSONDecodeError as e:
+    sys.stderr.write(f"ERROR: response was not JSON: {e}\n")
+    sys.exit(1)
+if not isinstance(payload, dict):
+    sys.stderr.write("ERROR: response was not a JSON object\n")
+    sys.exit(1)
+token = payload.get("token")
+if not isinstance(token, str) or not token:
+    # Diagnostics that NEVER emit a field VALUE (only type + length +
+    # the set of top-level keys). Even a "short" status string can be
+    # 32 ASCII chars of credential-shaped data; do not surface it.
+    keys = sorted(payload.keys())
+    status = payload.get("status")
+    status_diag = f"type={type(status).__name__}" + (
+        f" len={len(status)}" if isinstance(status, str) else ""
+    )
+    token_diag = f"type={type(token).__name__}" + (
+        f" len={len(token)}" if isinstance(token, str) else ""
+    )
+    sys.stderr.write(
+        f"ERROR: response did not contain a non-empty string \"token\" field; "
+        f"status_field={status_diag} token_field={token_diag} keys={keys}\n"
+    )
+    sys.exit(1)
+print(token, end="")
+'
+}
+
+cmd_wait_ready() {
+    [[ $# -lt 1 || $# -gt 2 ]] && usage
+    local url="$1"
+    local cacert="${2:-}"
+
+    # Read password from stdin (NOT env, NOT argv) into a local shell
+    # variable. After this call fd 0 is redirected to /dev/null so
+    # later heredocs do not consume stray stdin content.
+    local user="${DNS_ADMIN_USER:-admin}"
+    local pass
+    read_password_stdin pass
+
+    local user_enc pass_enc
+    user_enc=$(printf '%s' "$user" | url_encode_stdin)
+    pass_enc=$(printf '%s' "$pass" | url_encode_stdin)
+    unset pass
+
+    local attempts=60 i
+    for i in $(seq 1 "$attempts"); do
+        if post_form "${url}/api/user/login" "$cacert" >/dev/null 2>&1 <<EOF
+user=${user_enc}&pass=${pass_enc}
+EOF
+        then
+            echo "Endpoint ready after $i attempt(s)" >&2
+            return 0
+        fi
+        sleep 1
+    done
+    echo "ERROR: endpoint at ${url} never became ready (${attempts} attempts)" >&2
+    return 1
+}
+
+cmd_get_token() {
+    [[ $# -lt 2 || $# -gt 3 ]] && usage
+    local url="$1"
+    local token_name="$2"
+    local cacert="${3:-}"
+
+    # Read password from stdin (NOT env, NOT argv) into a local shell
+    # variable. After this call fd 0 is redirected to /dev/null so
+    # later heredocs do not consume stray stdin content.
+    local user="${DNS_ADMIN_USER:-admin}"
+    local pass
+    read_password_stdin pass
+
+    local user_enc pass_enc tn_enc
+    user_enc=$(printf '%s' "$user" | url_encode_stdin)
+    pass_enc=$(printf '%s' "$pass" | url_encode_stdin)
+    tn_enc=$(printf '%s' "$token_name" | url_encode_stdin)
+    unset pass
+
+    # Step 1: login -> session token
+    local login_resp session_token
+    if ! login_resp=$(post_form "${url}/api/user/login" "$cacert" <<EOF
+user=${user_enc}&pass=${pass_enc}
+EOF
+    ); then
+        echo "ERROR: /api/user/login POST failed against ${url}" >&2
+        return 1
+    fi
+    if ! session_token=$(printf '%s' "$login_resp" | extract_token_field); then
+        echo "ERROR: could not extract session token from login response" >&2
+        return 1
+    fi
+    if [[ -z "$session_token" ]]; then
+        echo "ERROR: login returned empty session token" >&2
+        return 1
+    fi
+
+    # Step 2: createToken -> API token
+    # Session token is a transient credential. Encode it locally; do
+    # not export it.
+    local st_enc
+    st_enc=$(printf '%s' "$session_token" | url_encode_stdin)
+    unset session_token
+
+    local create_resp api_token
+    if ! create_resp=$(post_form "${url}/api/user/createToken" "$cacert" <<EOF
+user=${user_enc}&pass=${pass_enc}&tokenName=${tn_enc}&token=${st_enc}
+EOF
+    ); then
+        echo "ERROR: /api/user/createToken POST failed against ${url}" >&2
+        return 1
+    fi
+    if ! api_token=$(printf '%s' "$create_resp" | extract_token_field); then
+        echo "ERROR: could not extract API token from createToken response" >&2
+        return 1
+    fi
+    if [[ -z "$api_token" ]]; then
+        echo "ERROR: createToken returned empty API token" >&2
+        return 1
+    fi
+
+    printf '%s\n' "$api_token"
+}
+
+main() {
+    [[ $# -lt 1 ]] && usage
+    local cmd="$1"
+    shift
+    case "$cmd" in
+        wait-ready) cmd_wait_ready "$@" ;;
+        get-token)  cmd_get_token  "$@" ;;
+        -h|--help|help) usage ;;
+        *) echo "ERROR: unknown subcommand: $cmd" >&2; usage ;;
+    esac
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

Closes #35.

The acceptance-test Makefile previously passed the Technitium admin password and per-run API session token to `curl` as URL query parameters, exposing them in `/proc/PID/cmdline` (visible via `ps -ef`) for every curl invocation. The `testacc` recipe additionally bulk-exported `.env.test` into the long-running `go test` process, putting `DNS_ADMIN_PASSWORD` into `/proc/PID/environ` for the test run.

This PR closes both surfaces by routing the password through a new helper script that reads it from stdin and never from argv or env.

## Implementation

### `scripts/test-token-bootstrap.sh` (new)
- Password read from stdin into a local shell variable; never argv, never env.
- URL-encoding via `python3` helper that also reads from stdin.
- Form bodies to `curl` via `--data @-` on bash heredocs.
- `set +x` early; CRLF input stripped defensively; `printf -v` (bash 3.2 / macOS safe).
- `extract_token_field` emits only type/length/key-set on error — never field values.
- Empty-token guards on both login and createToken responses.

### `GNUmakefile`
- `testacc-token`, `testacc-token-tls`, and the `testacc-up-tls` readiness probe rewritten to `printf '%s\n' \"$$PW\" | ./scripts/test-token-bootstrap.sh ...`.
- `testacc` switched from `grep -v '^#' .env.test | xargs` (subvertable by a single line with multiple `VAR=VAL` pairs) to a per-line allow-list that only exports keys matching `^TECHNITIUM_[A-Z0-9_]+$`.
- Each secret-handling recipe line begins with `set +x;` so inherited recipe-shell xtrace (`make SHELL='bash -x'` or `SHELLOPTS=xtrace`) cannot log secrets.
- `cut -d= -f2-` (was `-f2`) so passwords containing `=` are not truncated.
- Explicit `test -n \"$$API_TOKEN\"` guards before writing tokens.

### Docs
- `README.md`: replaced the "Known limitation" callout with a description of the new credential handling.
- `CHANGELOG.md`: Security subsection under `[Unreleased]` with #35 link.

No production code or wire shape changes.

## Verification

A continuous `/proc/*/environ` + `/proc/*/cmdline` watcher captured **0 leaks** across all non-Technitium-container processes during both `make testacc-token` (HTTP) and `make testacc-token-tls` (HTTPS). The Technitium container itself receives `DNS_ADMIN_PASSWORD` via `env_file` — the documented image bootstrap path, out of scope for #35.

Pre-push review: **four rounds of `codex exec --sandbox read-only` adversarial review** iterated to 0 criticals / 0 should-fixes. Surfaced findings — env-prefix env-leak, `testacc` bulk export, xargs allow-list bypass, xtrace, CRLF, status-message redaction, null-token guard, bash 3.2 compat — all addressed.

## Test plan

- [x] `bash -n scripts/test-token-bootstrap.sh` clean
- [x] `make -n` dry-run on all three touched recipes renders expected commands
- [x] `make testacc-token` (HTTP) provisions a token; watcher shows 0 leaks
- [x] `make testacc-token-tls` (HTTPS) provisions a token; watcher shows 0 leaks
- [x] Direct `printf 'admin\r\n' | ./scripts/... get-token URL LABEL` succeeds (CRLF handling)
- [x] Allow-list bypass simulation (`TECHNITIUM_API_TOKEN=x DNS_ADMIN_PASSWORD=y` on one line) produces only one export
- [x] Watcher sanity-checked: deliberate leak (`DNS_ADMIN_PASSWORD=admin sleep 2`) captured
- [ ] CI acceptance-tls workflow green after push

🤖 Generated with [Claude Code](https://claude.com/claude-code)