### PR TITLE
docs(community): add CONTRIBUTING + CoC + issue templates + PR template (closes #60)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,136 @@
+name: Bug report
+description: Report a misbehavior in the Technitium Terraform provider.
+title: "bug: "
+labels: ["bug", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug. The fields marked
+        required are the minimum the maintainer needs to diagnose; the
+        optional ones help if you happen to know the answer but should
+        not block you from filing.
+
+        **For security vulnerabilities, do NOT use this template.** See
+        [SECURITY.md](https://github.com/darkhonor/terraform-provider-technitium/blob/main/.github/SECURITY.md)
+        for the private disclosure path.
+
+  - type: input
+    id: provider-version
+    attributes:
+      label: Provider version
+      description: Output of `terraform version` showing the technitium provider line, or the value from your `required_providers` block.
+      placeholder: "1.2.0"
+    validations:
+      required: true
+
+  - type: input
+    id: terraform-version
+    attributes:
+      label: Terraform version
+      description: Output of `terraform version` (the first line).
+      placeholder: "Terraform v1.9.0"
+    validations:
+      required: true
+
+  - type: input
+    id: technitium-version
+    attributes:
+      label: Technitium DNS Server version
+      description: The version of the Technitium DNS Server you are running. Visible in the admin web console footer.
+      placeholder: "13.6.0"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: os
+    attributes:
+      label: OS / platform
+      description: Where the Terraform CLI is running, not where the DNS server is running.
+      options:
+        - Linux
+        - macOS
+        - Windows
+        - FreeBSD
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: Describe the misbehavior. What did `terraform plan` / `apply` / `destroy` actually do?
+    validations:
+      required: true
+
+  - type: textarea
+    id: what-expected
+    attributes:
+      label: What did you expect to happen?
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro-hcl
+    attributes:
+      label: Minimal reproducing HCL
+      description: The smallest configuration that demonstrates the bug. Provider block + the affected resource(s) is usually enough.
+      render: hcl
+    validations:
+      required: true
+
+  - type: textarea
+    id: tf-output
+    attributes:
+      label: terraform plan / apply output
+      description: |
+        Paste relevant output here. **Redact any tokens, passwords, or
+        internal hostnames before submitting.** Wrap large outputs in
+        `<details>` if needed.
+      render: shell
+    validations:
+      required: false
+
+  - type: dropdown
+    id: tls-mode
+    attributes:
+      label: TLS mode
+      description: How the provider is configured to reach the Technitium API.
+      options:
+        - Not sure
+        - HTTP
+        - HTTPS with publicly-trusted CA
+        - HTTPS with custom CA (ca_cert_file set)
+    validations:
+      required: false
+
+  - type: dropdown
+    id: stig-mode
+    attributes:
+      label: STIG enforcement mode
+      description: The value of `stig_compliance.enforcement` in the provider block, if set.
+      options:
+        - Not sure
+        - strict (default)
+        - warn
+        - silent
+        - N/A (stig_compliance.enabled = false)
+    validations:
+      required: false
+
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context
+      description: Anything else that might help -- screenshots, related issues, recent changes.
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: preflight
+    attributes:
+      label: Pre-flight
+      options:
+        - label: I searched existing open and closed issues and did not find a duplicate.
+          required: true

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -48,6 +48,7 @@ body:
       label: OS / platform
       description: Where the Terraform CLI is running, not where the DNS server is running.
       options:
+        - Not sure
         - Linux
         - macOS
         - Windows

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,14 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/darkhonor/terraform-provider-technitium/security/advisories/new
+    about: |
+      Do NOT open a public issue for security vulnerabilities. Use
+      GitHub's private vulnerability reporting form. See SECURITY.md
+      for the full policy.
+  - name: Usage question
+    url: https://github.com/darkhonor/terraform-provider-technitium/tree/main/docs
+    about: |
+      Read the provider docs and the STIG Compliance Guide before
+      filing an issue. If the docs are missing or unclear, file an
+      Enhancement with a docs-gap framing.

--- a/.github/ISSUE_TEMPLATE/enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/enhancement.yml
@@ -1,0 +1,106 @@
+name: Enhancement
+description: Suggest a new feature, capability, or improvement.
+title: "enhancement: "
+labels: ["enhancement", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to suggest an enhancement. Whether
+        this is a homelab quality-of-life request or a production /
+        compliance-driven feature, both contexts are welcome and both
+        shape the eventual design.
+
+  - type: input
+    id: summary
+    attributes:
+      label: Summary
+      description: One sentence describing the enhancement.
+      placeholder: "Expose the catalog_membership override flags on the resource"
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / use case
+      description: |
+        What are you trying to do? Why does the current provider make
+        it hard or impossible? Homelab or production context welcome --
+        both shape design.
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: What would the ideal behavior look like? Sketch of HCL is helpful when relevant.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches you weighed and why you set them aside.
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: surface
+    attributes:
+      label: Affected surface
+      description: Where in the provider this lands. Skip if unsure.
+      options:
+        - label: Resource (new resource or new fields on an existing one)
+        - label: Data source
+        - label: Provider configuration
+        - label: STIG validator
+        - label: Documentation
+        - label: Test infrastructure
+        - label: CI / build
+    validations:
+      required: false
+
+  - type: textarea
+    id: api-endpoints
+    attributes:
+      label: Technitium API endpoints involved
+      description: |
+        If the feature depends on specific Technitium API endpoints,
+        link the relevant section of [APIDOCS.md](https://github.com/TechnitiumSoftware/DnsServer/blob/master/APIDOCS.md).
+    validations:
+      required: false
+
+  - type: textarea
+    id: stig-impact
+    attributes:
+      label: STIG / NIST 800-53 impact
+      description: |
+        Does this touch a DNS-REQ-NNN requirement? Does it need a new
+        control mapping? Leave blank for ergonomics-only or homelab
+        quality-of-life requests.
+    validations:
+      required: false
+
+  - type: dropdown
+    id: backwards-compat
+    attributes:
+      label: Backwards-compatibility
+      description: How the change affects existing users.
+      options:
+        - Not sure
+        - Fully compatible (additive only)
+        - Behind a new field with safe default
+        - Breaking -- requires major-version bump
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: preflight
+    attributes:
+      label: Pre-flight
+      options:
+        - label: I searched existing open and closed issues and did not find a duplicate.
+          required: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,42 @@
+## Summary
+
+<!-- One or two sentences. What changes and why. -->
+
+## Type of change
+
+<!-- Check one or more. Match the type prefix of your commit subject. -->
+
+- [ ] fix -- bug fix
+- [ ] feat -- new feature
+- [ ] chore -- non-functional change (deps, build, tooling)
+- [ ] docs -- documentation only
+- [ ] test -- test infra or coverage
+- [ ] security -- security hardening
+- [ ] refactor -- no behavior change
+
+## Linked issue(s)
+
+<!-- For example: Closes #NN, Refs #NN. Use "Closes" so GitHub auto-closes the issue on merge. -->
+
+## Verification
+
+<!-- Commands you ran, results, screenshots, exact output if relevant.
+     Cite line numbers when referencing changed files. -->
+
+## CHANGELOG
+
+- [ ] Entry added under `[Unreleased]` in [CHANGELOG.md](../CHANGELOG.md)
+- [ ] N/A (doc-only or chore)
+
+## Compliance impact
+
+<!-- For changes that touch DNS configuration, validators, or the
+     security posture: any STIG / NIST 800-53 implication? Which
+     DNS-REQ rules are affected, if any?
+     For ergonomics-only, test-infra, or chore changes: write "N/A". -->
+
+## Pre-flight
+
+- [ ] Local unit tests pass (`make test`)
+- [ ] Lint clean (`make lint`)
+- [ ] No secrets, tokens, or internal hostnames in the diff

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,83 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at darkhonor@users.noreply.github.com. All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at [https://www.contributor-covenant.org/faq][FAQ]. Translations are available at [https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -36,7 +36,7 @@ This Code of Conduct applies within all community spaces, and also applies when 
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at darkhonor@users.noreply.github.com. All complaints will be reviewed and investigated promptly and fairly.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at conduct@darkhonor.com. All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the reporter of any incident.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,221 @@
+# Contributing to terraform-provider-technitium
+
+Thanks for your interest in contributing. This provider serves operators
+who want STIG-aligned Technitium DNS Server infrastructure as code, plus
+homelab tinkerers who want a clean Terraform path to a self-hosted DNS
+server. Both audiences are welcome, and the contribution process tries
+not to force one path on the other.
+
+## Code of Conduct
+
+This project follows the [Contributor Covenant 2.1](CODE_OF_CONDUCT.md).
+By participating, you agree to uphold it. Reports of conduct issues go
+to `darkhonor@users.noreply.github.com`.
+
+We expect everyone in the community to treat each other with respect.
+There is no place here for hate, harassment, or bullying in any form.
+
+## Asking for help vs. filing an issue
+
+- **Usage questions** (how do I configure `technitium_zone`? what does
+  `enforcement = "warn"` actually do?): start with the [provider docs](./docs/)
+  and the [STIG Compliance Guide](./docs/guides/stig-compliance.md). If
+  those don't answer your question, file an Enhancement issue with a
+  "docs gap" framing — that helps the project improve.
+- **Bug** (provider misbehaves, errors are confusing, drift appears
+  where it shouldn't): file a Bug issue with the template fields.
+- **Security vulnerability**: do NOT open a public issue. See
+  [Reporting a security vulnerability](#reporting-a-security-vulnerability)
+  below.
+
+## Reporting a bug
+
+Use the [Bug report](https://github.com/darkhonor/terraform-provider-technitium/issues/new?template=bug.yml)
+template. The form asks for the minimum the maintainer needs to diagnose:
+provider version, Terraform version, Technitium DNS Server version, OS,
+what happened, what you expected, and a minimal reproducing HCL snippet.
+Other fields (TLS mode, STIG enforcement mode, command output) are
+optional — fill them in if you know the answer; skip them if you don't.
+
+## Reporting a security vulnerability
+
+See [.github/SECURITY.md](.github/SECURITY.md) for the security policy.
+**Do not file a public issue for vulnerabilities.** Use GitHub's
+[private vulnerability reporting](https://github.com/darkhonor/terraform-provider-technitium/security/advisories/new)
+flow so the conversation stays private until a fix is available.
+
+## Suggesting an enhancement
+
+Use the [Enhancement](https://github.com/darkhonor/terraform-provider-technitium/issues/new?template=enhancement.yml)
+template. The form asks for a summary, the use case (homelab or
+production context welcome), and a proposed solution. Optional fields
+let you pre-mark the affected surface, link Technitium API endpoints,
+and call out STIG / NIST 800-53 implications when applicable.
+
+## Development setup
+
+### Prerequisites
+
+- [Go](https://go.dev/) >= 1.26
+- [Docker](https://www.docker.com/) (for acceptance tests)
+- [Terraform CLI](https://developer.hashicorp.com/terraform/install) (used by `terraform-plugin-testing`)
+- GNU Make
+
+### Clone and build
+
+```bash
+git clone https://github.com/darkhonor/terraform-provider-technitium.git
+cd terraform-provider-technitium
+make build
+```
+
+### Running unit tests
+
+```bash
+make test
+```
+
+Unit tests run entirely offline.
+
+### Running acceptance tests
+
+The acceptance suite spins up a Technitium DNS Server container via
+docker-compose, provisions a fresh API token, and exercises every
+resource against a live server.
+
+```bash
+make testacc-up      # HTTP-mode acceptance suite
+make testacc-down    # teardown
+
+make testacc-up-tls  # HTTPS-mode acceptance suite (TLS fixtures + STIG-strict tests)
+make testacc-down-tls
+```
+
+The test container runs as your host user (issue #36), and the token
+bootstrap helper pipes the admin password to `curl` on stdin rather
+than via argv or env (issue #35) — so neither shows up in process
+listings during the run.
+
+### FIPS build
+
+```bash
+make build-fips    # GOEXPERIMENT=boringcrypto build
+make test-fips     # FIPS-mode unit tests
+```
+
+### Regenerating docs
+
+The provider docs under `docs/` are generated from the templates under
+`templates/` plus the resource schema:
+
+```bash
+make generate
+```
+
+If you change a resource schema, an example, or a template, regenerate
+the docs and commit the result. CI's `Verify Docs` job will fail otherwise.
+
+## Code style
+
+- Go code is formatted by `gofmt` and linted by `golangci-lint`.
+- The lint configuration lives at [.golangci.yml](./.golangci.yml).
+- CI fails on lint violations; run `make lint` locally before pushing.
+- Tests are written in the standard `testing` package style for unit
+  tests and via `terraform-plugin-testing` for acceptance tests.
+
+## Commit message conventions
+
+This repo uses [Conventional Commits](https://www.conventionalcommits.org/).
+The type prefix carries information for the changelog generator and for
+human readers scanning `git log`. Examples from the actual repo history:
+
+```
+fix(security): eliminate credential argv/env exposure in test harness (closes #35)
+security(ci): enforce GitHub Actions SHA pinning
+test(infra): run Technitium test container as non-root host user (closes #36)
+fix(deps): update module github.com/hashicorp/terraform-plugin-testing to v1.16.0
+chore(deps): pin technitium/dns-server docker tag
+```
+
+Common types: `feat`, `fix`, `chore`, `docs`, `test`, `refactor`,
+`security`. Scope is optional but encouraged (`fix(client):`,
+`feat(catalog):`, `chore(deps):`, `docs(readme):`).
+
+Signed commits are not required.
+
+## Pull request process
+
+### Branch naming
+
+- `feature/issue-NN-short-slug` for new features
+- `fix/issue-NN-short-slug` for bug fixes
+- `docs/issue-NN-short-slug` for documentation
+- `chore/short-slug` for renovate-bot, build, or non-functional changes
+
+If an issue number is not available, omit the `issue-NN` segment.
+
+### CI gates
+
+Every PR must pass:
+
+- `Lint` — `golangci-lint`
+- `Unit Tests` — `make test`
+- `FIPS Build` — `GOEXPERIMENT=boringcrypto go build ./...`
+- `Acceptance Tests (TLS)` — full TLS-mode acceptance suite
+- `Security Scan` — `gosec` + `govulncheck`
+- `CodeQL` — static analysis
+- `Verify action SHA pins` — `pinact` enforces full 40-char SHA pins on every `uses:` reference
+- `Verify Docs` — generated docs match templates + schema
+
+### CHANGELOG entry
+
+Add an entry to the `[Unreleased]` section of [CHANGELOG.md](./CHANGELOG.md)
+in [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format. Use
+the appropriate subsection: `Added`, `Changed`, `Deprecated`, `Removed`,
+`Fixed`, `Security`, `Known limitations`, or `Upgrade Notes`.
+
+Documentation-only and chore PRs may skip the CHANGELOG entry.
+
+### Review and merge
+
+- All CI gates must be green before review.
+- At least one maintainer approval is required.
+- Squash-merge is the default; the squashed commit subject should follow
+  Conventional Commits.
+
+## Compliance posture
+
+This provider markets STIG-aligned DNS hardening with full NIST 800-53
+control traceability. When proposing a feature or fixing a bug:
+
+- If the change touches DNS configuration that the embedded validators
+  evaluate, consider whether a DNS-REQ validator should be added,
+  modified, or extended. See the [STIG Compliance Guide](./docs/guides/stig-compliance.md)
+  for the requirement framework.
+- New validators must include test coverage in
+  `internal/provider/validators/`.
+- Validator changes that affect the NSS / CNSSI 1253 baseline must be
+  noted in the PR description so the categorization tables stay accurate.
+
+Ergonomics-only changes and test-infra work have no compliance impact;
+the PR template lets you mark this explicitly.
+
+## License
+
+This project is licensed under the [Mozilla Public License 2.0](./LICENSE).
+By submitting a contribution, you affirm that you have the right to
+license it under MPL-2.0 (inbound = outbound).
+
+## LLM attribution
+
+If you used an LLM-based coding assistant (Claude Code, GitHub Copilot,
+Cursor, Aider, etc.) to materially contribute to a commit, add a
+`Co-Authored-By:` trailer attributing the tool. This keeps the audit
+trail explicit without favoring any particular provider:
+
+```
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+```
+
+Pick the email the tool's documentation recommends, or use
+`noreply@<vendor>.com` if none is given.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ not to force one path on the other.
 
 This project follows the [Contributor Covenant 2.1](CODE_OF_CONDUCT.md).
 By participating, you agree to uphold it. Reports of conduct issues go
-to `darkhonor@users.noreply.github.com`.
+to `conduct@darkhonor.com`.
 
 We expect everyone in the community to treat each other with respect.
 There is no place here for hate, harassment, or bullying in any form.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,7 +56,7 @@ and call out STIG / NIST 800-53 implications when applicable.
 
 ### Prerequisites
 
-- [Go](https://go.dev/) >= 1.26
+- [Go](https://go.dev/) >= 1.26.3 (matches the `go` directive in `go.mod`)
 - [Docker](https://www.docker.com/) (for acceptance tests)
 - [Terraform CLI](https://developer.hashicorp.com/terraform/install) (used by `terraform-plugin-testing`)
 - GNU Make
@@ -150,6 +150,7 @@ Signed commits are not required.
 - `feature/issue-NN-short-slug` for new features
 - `fix/issue-NN-short-slug` for bug fixes
 - `docs/issue-NN-short-slug` for documentation
+- `security/short-slug` for supply-chain or hardening changes
 - `chore/short-slug` for renovate-bot, build, or non-functional changes
 
 If an issue number is not available, omit the `issue-NN` segment.
@@ -214,8 +215,13 @@ Cursor, Aider, etc.) to materially contribute to a commit, add a
 trail explicit without favoring any particular provider:
 
 ```
-Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+Co-Authored-By: <Tool Name> <noreply@<vendor>.com>
 ```
 
-Pick the email the tool's documentation recommends, or use
-`noreply@<vendor>.com` if none is given.
+Pick the email the tool's documentation recommends, or use the vendor's
+`noreply@` address if none is given. Examples (illustrative, not
+prescriptive):
+
+- `Co-Authored-By: GitHub Copilot <noreply@github.com>`
+- `Co-Authored-By: Cursor <noreply@cursor.sh>`
+- `Co-Authored-By: Claude Code <noreply@anthropic.com>`


### PR DESCRIPTION
## Summary

Adds six community-health files this repo did not previously have. Closes #60.

- `CODE_OF_CONDUCT.md` — Contributor Covenant 2.1 verbatim from the canonical source, with the enforcement contact set to `conduct@darkhonor.com`.
- `CONTRIBUTING.md` — full contributor guide: project values, CoC link, asking-for-help vs filing-an-issue, bug / security / enhancement paths, development setup (prereqs, build, unit + acceptance tests, FIPS, regenerating docs), code style, Conventional Commits with examples drawn from live `git log` on `origin/main`, PR process (branch naming including `security/`, CI gates, CHANGELOG conventions), compliance posture for STIG / NIST 800-53 touching changes, MPL-2.0 inbound = outbound licensing, and vendor-neutral LLM attribution guidance.
- `.github/ISSUE_TEMPLATE/bug.yml` — GitHub Forms. 8 required fields (provider / Terraform / Technitium versions, OS, what happened, expected, repro HCL, searched-issues check); 4 optional (output, TLS mode, STIG mode, additional context). Every dropdown includes a "Not sure" option so homelab reporters never have to guess.
- `.github/ISSUE_TEMPLATE/enhancement.yml` — GitHub Forms. 4 required (summary, problem, solution, searched-issues); 5 optional (alternatives, surface, API endpoints, STIG impact, backwards-compat).
- `.github/ISSUE_TEMPLATE/config.yml` — disables blank issues; `contact_links` route "Security vulnerability" to the private GitHub Security Advisory form (matches the policy in `.github/SECURITY.md`) and "Usage question" to the `docs/` tree.
- `.github/pull_request_template.md` — Summary, Type, Linked issue, Verification, CHANGELOG checkbox (with N/A option), Compliance impact, Pre-flight checklist.

Required-field philosophy: only ask what the maintainer cannot diagnose without. Everything else is optional with helpful placeholder text. Homelab reporters welcome.

## Type of change

- [x] docs — documentation only

## Linked issue(s)

Closes #60.

## Verification

- `git diff --stat origin/main..HEAD` shows exactly the six new files (status `A`).
- `python3 -c "import yaml; yaml.safe_load(open(...))"` returns clean for all three `ISSUE_TEMPLATE/*.yml` files.
- `CONTRIBUTING.md` internal link sweep: all 7 internal paths resolve (`CHANGELOG.md`, `CODE_OF_CONDUCT.md`, `docs/`, `docs/guides/stig-compliance.md`, `.github/SECURITY.md`, `.golangci.yml`, `LICENSE`).
- `CODE_OF_CONDUCT.md` diffed against the canonical Contributor Covenant 2.1 raw source (TOML front-matter stripped, `[INSERT CONTACT METHOD]` replaced): only difference is one leading blank-line whitespace, semantically irrelevant.
- Conventional Commits examples in `CONTRIBUTING.md` verified against actual `git log --oneline origin/main` subjects, not training-data recall.
- Pre-push adversarial review via `codex exec --sandbox read-only`: iterated to 0 criticals + 0 should-fix. Round-1 caught three should-fix items (missing "Not sure" in OS dropdown, Go version mismatch with `go.mod`, vendor-locked LLM example), all fixed in `8b3e8bd`. Round-2 caught that the original `darkhonor@users.noreply.github.com` contact was a GitHub outbound-only noreply domain that drops inbound mail — fixed in `f3790f6` by switching to `conduct@darkhonor.com`, an operator-owned alias that forwards to a monitored inbox.

## CHANGELOG

- [ ] Entry added under `[Unreleased]`
- [x] N/A — PR #54 will consolidate the full v1.2.0 changelog including this work.

## Compliance impact

N/A — community-health docs only. No provider, workflow, validator, or test changes. CI gates run unchanged on this PR.

## Pre-flight

- [x] Local `bash`/YAML syntax checks pass
- [x] `make lint` clean (no Go changes)
- [x] No secrets, tokens, or internal hostnames in the diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)