### PR TITLE
ci: make action pin check deterministic

### DIFF
--- a/.github/scripts/verify-action-pins.sh
+++ b/.github/scripts/verify-action-pins.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+fail=0
+
+while IFS= read -r -d '' file; do
+  line_number=0
+
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    line_number=$((line_number + 1))
+
+    [[ "$line" =~ ^[[:space:]]*# ]] && continue
+
+    if [[ "$line" =~ ^[[:space:]]*(-[[:space:]]*)?uses:[[:space:]]*([^[:space:]#]+) ]]; then
+      ref="${BASH_REMATCH[2]}"
+      ref="${ref%\"}"
+      ref="${ref#\"}"
+      ref="${ref%\'}"
+      ref="${ref#\'}"
+
+      case "$ref" in
+        ./*|docker://*) continue ;;
+      esac
+
+      if [[ ! "$ref" =~ @([0-9a-fA-F]{40})$ ]]; then
+        printf '%s:%d: external action is not pinned to a full 40-character SHA: %s\n' \
+          "$file" "$line_number" "$ref" >&2
+        fail=1
+      fi
+    fi
+  done < "$file"
+done < <(find .github/workflows -type f \( -name '*.yml' -o -name '*.yaml' \) -print0 | sort -z)
+
+if (( fail )); then
+  exit 1
+fi
+
+printf 'All external GitHub Actions uses references are pinned to full commit SHAs.\n'

--- a/.github/workflows/pin-actions.yml
+++ b/.github/workflows/pin-actions.yml
@@ -20,12 +20,7 @@ jobs:
           persist-credentials: false
 
       # Security ratchet for issue #56: every GitHub Actions uses reference
-      # must be pinned to a full 40-character commit SHA. pinact-action itself
-      # is also SHA-pinned so the enforcement tool does not become the new
-      # mutable supply-chain dependency.
+      # must be pinned to a full 40-character commit SHA. Keep this check
+      # offline so transient GitHub API failures cannot mask real regressions.
       - name: Verify GitHub Actions are SHA-pinned
-        uses: suzuki-shunsuke/pinact-action@cf51507d80d4d6522a07348e3d58790290eaf0b6 # v2.0.0
-        with:
-          skip_push: "true"
-          verify: "true"
-          github_token: ${{ github.token }}
+        run: bash .github/scripts/verify-action-pins.sh


### PR DESCRIPTION
## Summary

Fixes #62 by replacing the intermittent `pinact-action` CI gate with an offline verifier that enforces the repository's GitHub Actions pinning policy directly.

The previous workflow used `pinact-action@v2.0.0`, which bundles `pinact@v3.9.0`. Upstream `pinact` currently has reports that pinned actions with trailing version comments can trigger GitHub API lookups and token/rate-limit-sensitive failures. That matches the observed `401 Bad credentials` failures when resolving `# vX.Y.Z` comments.

## What changed

- Added `.github/scripts/verify-action-pins.sh`
- Updated `.github/workflows/pin-actions.yml` to run the local verifier
- Kept the policy scoped to the actual CI goal: external `uses:` references in workflow YAML must end in a full 40-character commit SHA
- Avoided GitHub API calls so transient auth/rate-limit issues cannot mask real pinning regressions

## Verification

- `actionlint .github/workflows/*.yml`
- `bash -n .github/scripts/verify-action-pins.sh`
- `bash .github/scripts/verify-action-pins.sh`
- Negative test by changing one checkout reference to `actions/checkout@v6`; verifier failed with the expected file/line message
