### PR TITLE
FWD record: include dnssec_validation in import IDs for state identity

### DIFF
--- a/docs/resources/record.md
+++ b/docs/resources/record.md
@@ -3,13 +3,13 @@ subcategory: ""
 page_title: "technitium_record Resource - Technitium DNS Server"
 description: |-
   Manages a DNS record in a Technitium DNS zone. Supports A, AAAA, CNAME, MX, TXT, SRV,
-  PTR, NS, and CAA record types. Client-side validation ensures type/value compatibility
+  PTR, NS, CAA, and FWD record types. Client-side validation ensures type/value compatibility
   before API calls.
 ---
 
 # technitium\_record (Resource)
 
-Manages a DNS record in a Technitium DNS zone. Supports A, AAAA, CNAME, MX, TXT, SRV, PTR, NS, and CAA record types. Client-side validation ensures type/value compatibility before API calls.
+Manages a DNS record in a Technitium DNS zone. Supports A, AAAA, CNAME, MX, TXT, SRV, PTR, NS, CAA, and FWD record types. Client-side validation ensures type/value compatibility before API calls.
 
 -> The `overwrite` attribute controls whether this record replaces existing records of the same type at the same name. Default is `true`.
 
@@ -136,9 +136,9 @@ resource "technitium_record" "web2" {
 
 * `name` - (Required, String) FQDN for the record. (Forces replacement.)
 
-* `type` - (Required, String) Record type. Valid values: `A`, `AAAA`, `CNAME`, `MX`, `TXT`, `SRV`, `PTR`, `NS`, `CAA`. (Forces replacement.)
+* `type` - (Required, String) Record type. Valid values: `A`, `AAAA`, `CNAME`, `MX`, `TXT`, `SRV`, `PTR`, `NS`, `CAA`, `FWD`. (Forces replacement.)
 
-* `value` - (Required, String) Record data.
+* `value` - (Required, String) Record data. For `FWD`, this is the forwarder address using Technitium name-server address syntax, e.g. `1.1.1.1`, `dns.quad9.net:853 (9.9.9.9)`, or a DoH URL.
 
 * `ttl` - (Optional, Integer) TTL in seconds. Default: `3600`.
 
@@ -152,13 +152,21 @@ resource "technitium_record" "web2" {
 
 * `caa_tag` - (Optional, String) CAA tag. Valid values: `issue`, `issuewild`, `iodef`.
 
+* `protocol` - (Optional, String) Protocol for `FWD` records. Valid values: `Udp`, `Tcp`, `Tls`, `Https`, `Quic`.
+
+* `forwarder_priority` - (Optional, Integer) Priority for `FWD` records. Lower values are queried first.
+
+* `dnssec_validation` - (Optional, Boolean) Enable DNSSEC validation for `FWD` records.
+
+* `proxy_type`, `proxy_address`, `proxy_port`, `proxy_username`, `proxy_password` - (Optional) Proxy settings for `FWD` records. `proxy_password` is sensitive.
+
 * `overwrite` - (Optional, Boolean) Replace existing record set. Default: `true`.
 
 ## Attributes Reference
 
 In addition to the arguments above, the following computed attributes are exported:
 
-* `id` - Record identifier (`zone::name::type::value` composite key). For MX records: `zone::name::MX::exchange:priority`. For SRV records: `zone::name::SRV::target:priority:weight:port`. For CAA records: `zone::name::CAA::value:flags:tag`.
+* `id` - Record identifier (`zone::name::type::value` composite key). For MX records: `zone::name::MX::exchange:priority`. For SRV records: `zone::name::SRV::target:priority:weight:port`. For CAA records: `zone::name::CAA::value:flags:tag`. For FWD records: `zone::name::FWD::forwarder:protocol:priority`.
 
 * `last_modified` - Timestamp of last modification.
 
@@ -178,4 +186,7 @@ terraform import technitium_record.sip "example.com::_sip._tcp.example.com::SRV:
 
 # CAA record (value:flags:tag)
 terraform import technitium_record.caa "example.com::example.com::CAA::letsencrypt.org:0:issue"
+
+# FWD record (forwarder:protocol:priority)
+terraform import technitium_record.forwarder ".::.::FWD::1.1.1.1:Udp:2"
 ```

--- a/docs/resources/record.md
+++ b/docs/resources/record.md
@@ -239,7 +239,7 @@ records match on the first three:
 * **Changing one merges the two.** An in-place update rewrites one record onto the other,
   leaving a single record where there were two — again reported as success.
 
-Verified against Technitium DNS Server 15.4.
+Verified against Technitium DNS Server 15.2 and 15.4.
 
 **What the provider does about it.** Changing `dnssec_validation` is treated as requiring
 replacement, so the provider never issues the in-place update that merges records. That

--- a/docs/resources/record.md
+++ b/docs/resources/record.md
@@ -110,7 +110,35 @@ resource "technitium_record" "ptr" {
 
 ### FWD Forwarder Records
 
+Forwarder zones are created empty; each upstream forwarder is then managed as its own
+`technitium_record` resource. The simplest case is a single forwarder:
+
 ```hcl
+# Simplest case: forward everything to one upstream resolver.
+#
+# A Forwarder zone is created empty, then the forwarder itself is a separate
+# FWD record. dnssec_validation is optional and can be left out entirely — with
+# a single forwarder there is nothing for it to be confused with.
+resource "technitium_zone" "forwarder" {
+  name = "."
+  type = "Forwarder"
+}
+
+resource "technitium_record" "upstream" {
+  zone      = technitium_zone.forwarder.name
+  name      = "."
+  type      = "FWD"
+  value     = "1.1.1.1"
+  protocol  = "Udp"
+  overwrite = false
+}
+```
+
+A fuller example, with DNSSEC validation over DNS-over-TLS and a plain fallback:
+
+```hcl
+# Full example: a primary forwarder with DNSSEC validation over DNS-over-TLS,
+# plus a plain fallback.
 resource "technitium_zone" "root_forwarder" {
   name = "."
   type = "Forwarder"
@@ -127,6 +155,15 @@ resource "technitium_record" "quad9_forwarder" {
   overwrite          = false
 }
 
+# Lower priority is queried first, so this is the fallback. It also differs from
+# the record above by value and protocol, which keeps the two independently
+# addressable.
+#
+# When several forwarders share a zone, make sure any two differ by something
+# other than dnssec_validation alone — value, protocol or forwarder_priority.
+# Records that differ ONLY by dnssec_validation cannot be told apart by the
+# Technitium API and one of them can be silently lost. See "DNSSEC validation on
+# forwarders" in the resource documentation.
 resource "technitium_record" "cloudflare_fallback" {
   zone               = technitium_zone.root_forwarder.name
   name               = "."
@@ -134,16 +171,61 @@ resource "technitium_record" "cloudflare_fallback" {
   value              = "1.1.1.1"
   protocol           = "Udp"
   forwarder_priority = 2
+  dnssec_validation  = false
   overwrite          = false
 }
 ```
 
+Conditional forwarding — send a single internal namespace to the resolvers authoritative
+for it, with a redundant pair of upstreams:
+
+```hcl
+# Conditional forwarding: send one internal namespace to the resolvers that are
+# authoritative for it, while everything else follows the server's normal path.
+#
+# The Forwarder zone is named for the domain being forwarded rather than "." —
+# only queries under that domain are forwarded.
+resource "technitium_zone" "corp_internal" {
+  name = "corp.example.net"
+  type = "Forwarder"
+}
+
+# Two upstreams for redundancy. They differ by value, so they remain
+# individually addressable; the priorities set which is tried first.
+resource "technitium_record" "corp_dns_primary" {
+  zone               = technitium_zone.corp_internal.name
+  name               = technitium_zone.corp_internal.name
+  type               = "FWD"
+  value              = "10.10.0.53"
+  protocol           = "Udp"
+  forwarder_priority = 1
+  overwrite          = false
+}
+
+resource "technitium_record" "corp_dns_secondary" {
+  zone               = technitium_zone.corp_internal.name
+  name               = technitium_zone.corp_internal.name
+  type               = "FWD"
+  value              = "10.20.0.53"
+  protocol           = "Udp"
+  forwarder_priority = 2
+  overwrite          = false
+}
+
+# Internal resolvers usually serve names that do not validate publicly, so
+# DNSSEC validation is left off here. Set dnssec_validation = true only for
+# upstreams you expect to return signed, publicly-validatable answers.
+```
+
 #### DNSSEC validation on forwarders
 
-~> **Do not define two `FWD` records that share the same `value`, `protocol` and
-`forwarder_priority` and differ only by `dnssec_validation`.** Technitium cannot tell
-such records apart, and Terraform cannot protect you from it. You may silently lose a
-record.
+**If you have a single forwarder, none of this applies** — `dnssec_validation` is optional,
+and leaving it out is fine.
+
+~> **With several forwarders on one zone, do not let any two differ only by
+`dnssec_validation`.** If two `FWD` records share the same `value`, `protocol` and
+`forwarder_priority`, Technitium cannot tell them apart, and you may silently lose one.
+Terraform cannot protect you from it.
 
 You do not need to know anything about DNSSEC for this to affect you — it is enough that
 two forwarder records look identical apart from that one true/false setting.
@@ -166,8 +248,9 @@ cannot rescue a pair that already collides, because the API offers no way to add
 without the other.
 
 **How to stay safe.** Give forwarders that should coexist a distinguishing
-`forwarder_priority` (or a different `protocol`). Priority is part of the record's identity,
-so records that differ by it are addressed correctly:
+`forwarder_priority` (or a different `value` or `protocol`). All three are part of the
+record's identity, so records that differ by any of them are addressed correctly. Priority
+is usually the natural choice, since it also controls query order — lower is tried first:
 
 ```hcl
 resource "technitium_record" "validating" {

--- a/docs/resources/record.md
+++ b/docs/resources/record.md
@@ -138,6 +138,62 @@ resource "technitium_record" "cloudflare_fallback" {
 }
 ```
 
+#### DNSSEC validation on forwarders
+
+~> **Do not define two `FWD` records that share the same `value`, `protocol` and
+`forwarder_priority` and differ only by `dnssec_validation`.** Technitium cannot tell
+such records apart, and Terraform cannot protect you from it. You may silently lose a
+record.
+
+You do not need to know anything about DNSSEC for this to affect you — it is enough that
+two forwarder records look identical apart from that one true/false setting.
+
+**What goes wrong.** The Technitium API identifies a forwarder record by its forwarder
+address, protocol and priority. `dnssec_validation` is not part of that lookup, so when two
+records match on the first three:
+
+* **Destroying one destroys the wrong one.** The API deletes whichever record was created
+  first and reports success. Terraform believes it removed the resource you asked for.
+* **Changing one merges the two.** An in-place update rewrites one record onto the other,
+  leaving a single record where there were two — again reported as success.
+
+Verified against Technitium DNS Server 15.4.
+
+**What the provider does about it.** Changing `dnssec_validation` is treated as requiring
+replacement, so the provider never issues the in-place update that merges records. That
+protects the ordinary case of a single forwarder whose setting you want to change. It
+cannot rescue a pair that already collides, because the API offers no way to address one
+without the other.
+
+**How to stay safe.** Give forwarders that should coexist a distinguishing
+`forwarder_priority` (or a different `protocol`). Priority is part of the record's identity,
+so records that differ by it are addressed correctly:
+
+```hcl
+resource "technitium_record" "validating" {
+  zone               = technitium_zone.fwd.name
+  name               = technitium_zone.fwd.name
+  type               = "FWD"
+  value              = "1.1.1.1"
+  protocol           = "Udp"
+  forwarder_priority = 1
+  dnssec_validation  = true
+}
+
+resource "technitium_record" "non_validating" {
+  zone               = technitium_zone.fwd.name
+  name               = technitium_zone.fwd.name
+  type               = "FWD"
+  value              = "1.1.1.1"
+  protocol           = "Udp"
+  forwarder_priority = 2 # distinct priority keeps the two records addressable
+  dnssec_validation  = false
+}
+```
+
+If you have already created a colliding pair, remove both records and recreate them with
+distinct priorities rather than trying to delete one.
+
 ### Multiple Records at Same Name (Round-Robin)
 
 ```hcl
@@ -187,6 +243,9 @@ resource "technitium_record" "web2" {
 * `forwarder_priority` - (Optional, Integer) Priority for `FWD` records. Lower values are queried first.
 
 * `dnssec_validation` - (Optional, Boolean) Enable DNSSEC validation for `FWD` records.
+  Changing this value forces the record to be **replaced** (destroyed and recreated) rather
+  than updated in place. See [DNSSEC validation on forwarders](#dnssec-validation-on-forwarders)
+  before defining two forwarders that differ only by this setting.
 
 * `proxy_type`, `proxy_address`, `proxy_port`, `proxy_username`, `proxy_password` - (Optional) Proxy settings for `FWD` records. `proxy_password` is sensitive.
 

--- a/docs/resources/record.md
+++ b/docs/resources/record.md
@@ -108,6 +108,36 @@ resource "technitium_record" "ptr" {
 }
 ```
 
+### FWD Forwarder Records
+
+```hcl
+resource "technitium_zone" "root_forwarder" {
+  name = "."
+  type = "Forwarder"
+}
+
+resource "technitium_record" "quad9_forwarder" {
+  zone               = technitium_zone.root_forwarder.name
+  name               = "."
+  type               = "FWD"
+  value              = "dns.quad9.net:853 (9.9.9.9)"
+  protocol           = "Tls"
+  forwarder_priority = 1
+  dnssec_validation  = true
+  overwrite          = false
+}
+
+resource "technitium_record" "cloudflare_fallback" {
+  zone               = technitium_zone.root_forwarder.name
+  name               = "."
+  type               = "FWD"
+  value              = "1.1.1.1"
+  protocol           = "Udp"
+  forwarder_priority = 2
+  overwrite          = false
+}
+```
+
 ### Multiple Records at Same Name (Round-Robin)
 
 ```hcl
@@ -166,7 +196,7 @@ resource "technitium_record" "web2" {
 
 In addition to the arguments above, the following computed attributes are exported:
 
-* `id` - Record identifier (`zone::name::type::value` composite key). For MX records: `zone::name::MX::exchange:priority`. For SRV records: `zone::name::SRV::target:priority:weight:port`. For CAA records: `zone::name::CAA::value:flags:tag`. For FWD records: `zone::name::FWD::forwarder:protocol:priority`.
+* `id` - Record identifier (`zone::name::type::value` composite key). For MX records: `zone::name::MX::exchange:priority`. For SRV records: `zone::name::SRV::target:priority:weight:port`. For CAA records: `zone::name::CAA::value:flags:tag`. For FWD records: `zone::name::FWD::forwarder:protocol:priority:dnssecValidation`. The `dnssecValidation` field distinguishes otherwise-identical forwarders; the legacy 3-field form `forwarder:protocol:priority` is still accepted on import for backward compatibility.
 
 * `last_modified` - Timestamp of last modification.
 
@@ -187,6 +217,9 @@ terraform import technitium_record.sip "example.com::_sip._tcp.example.com::SRV:
 # CAA record (value:flags:tag)
 terraform import technitium_record.caa "example.com::example.com::CAA::letsencrypt.org:0:issue"
 
-# FWD record (forwarder:protocol:priority)
-terraform import technitium_record.forwarder ".::.::FWD::1.1.1.1:Udp:2"
+# FWD record (forwarder:protocol:priority:dnssecValidation)
+terraform import technitium_record.forwarder ".::.::FWD::1.1.1.1:Udp:2:true"
+
+# FWD record, legacy 3-field form (still accepted; dnssec_validation is left unset)
+terraform import technitium_record.forwarder_legacy ".::.::FWD::1.1.1.1:Udp:2"
 ```

--- a/examples/resources/technitium_record/fwd-record-conditional.tf
+++ b/examples/resources/technitium_record/fwd-record-conditional.tf
@@ -1,0 +1,35 @@
+# Conditional forwarding: send one internal namespace to the resolvers that are
+# authoritative for it, while everything else follows the server's normal path.
+#
+# The Forwarder zone is named for the domain being forwarded rather than "." —
+# only queries under that domain are forwarded.
+resource "technitium_zone" "corp_internal" {
+  name = "corp.example.net"
+  type = "Forwarder"
+}
+
+# Two upstreams for redundancy. They differ by value, so they remain
+# individually addressable; the priorities set which is tried first.
+resource "technitium_record" "corp_dns_primary" {
+  zone               = technitium_zone.corp_internal.name
+  name               = technitium_zone.corp_internal.name
+  type               = "FWD"
+  value              = "10.10.0.53"
+  protocol           = "Udp"
+  forwarder_priority = 1
+  overwrite          = false
+}
+
+resource "technitium_record" "corp_dns_secondary" {
+  zone               = technitium_zone.corp_internal.name
+  name               = technitium_zone.corp_internal.name
+  type               = "FWD"
+  value              = "10.20.0.53"
+  protocol           = "Udp"
+  forwarder_priority = 2
+  overwrite          = false
+}
+
+# Internal resolvers usually serve names that do not validate publicly, so
+# DNSSEC validation is left off here. Set dnssec_validation = true only for
+# upstreams you expect to return signed, publicly-validatable answers.

--- a/examples/resources/technitium_record/fwd-record-simple.tf
+++ b/examples/resources/technitium_record/fwd-record-simple.tf
@@ -1,0 +1,18 @@
+# Simplest case: forward everything to one upstream resolver.
+#
+# A Forwarder zone is created empty, then the forwarder itself is a separate
+# FWD record. dnssec_validation is optional and can be left out entirely — with
+# a single forwarder there is nothing for it to be confused with.
+resource "technitium_zone" "forwarder" {
+  name = "."
+  type = "Forwarder"
+}
+
+resource "technitium_record" "upstream" {
+  zone      = technitium_zone.forwarder.name
+  name      = "."
+  type      = "FWD"
+  value     = "1.1.1.1"
+  protocol  = "Udp"
+  overwrite = false
+}

--- a/examples/resources/technitium_record/fwd-record.tf
+++ b/examples/resources/technitium_record/fwd-record.tf
@@ -1,0 +1,25 @@
+resource "technitium_zone" "root_forwarder" {
+  name = "."
+  type = "Forwarder"
+}
+
+resource "technitium_record" "quad9_forwarder" {
+  zone               = technitium_zone.root_forwarder.name
+  name               = "."
+  type               = "FWD"
+  value              = "dns.quad9.net:853 (9.9.9.9)"
+  protocol           = "Tls"
+  forwarder_priority = 1
+  dnssec_validation  = true
+  overwrite          = false
+}
+
+resource "technitium_record" "cloudflare_fallback" {
+  zone               = technitium_zone.root_forwarder.name
+  name               = "."
+  type               = "FWD"
+  value              = "1.1.1.1"
+  protocol           = "Udp"
+  forwarder_priority = 2
+  overwrite          = false
+}

--- a/examples/resources/technitium_record/fwd-record.tf
+++ b/examples/resources/technitium_record/fwd-record.tf
@@ -1,3 +1,5 @@
+# Full example: a primary forwarder with DNSSEC validation over DNS-over-TLS,
+# plus a plain fallback.
 resource "technitium_zone" "root_forwarder" {
   name = "."
   type = "Forwarder"
@@ -14,6 +16,15 @@ resource "technitium_record" "quad9_forwarder" {
   overwrite          = false
 }
 
+# Lower priority is queried first, so this is the fallback. It also differs from
+# the record above by value and protocol, which keeps the two independently
+# addressable.
+#
+# When several forwarders share a zone, make sure any two differ by something
+# other than dnssec_validation alone — value, protocol or forwarder_priority.
+# Records that differ ONLY by dnssec_validation cannot be told apart by the
+# Technitium API and one of them can be silently lost. See "DNSSEC validation on
+# forwarders" in the resource documentation.
 resource "technitium_record" "cloudflare_fallback" {
   zone               = technitium_zone.root_forwarder.name
   name               = "."
@@ -21,5 +32,6 @@ resource "technitium_record" "cloudflare_fallback" {
   value              = "1.1.1.1"
   protocol           = "Udp"
   forwarder_priority = 2
+  dnssec_validation  = false
   overwrite          = false
 }

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -75,6 +75,37 @@ func TestNewClient_SkipTLSVerify(t *testing.T) {
 	}
 }
 
+func TestZoneCreate_ForwarderCreatesEmptyZone(t *testing.T) {
+	ts := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/zones/create" {
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+		q := r.URL.Query()
+		if q.Get("zone") != "." || q.Get("type") != "Forwarder" {
+			t.Fatalf("unexpected create query: %s", r.URL.RawQuery)
+		}
+		if q.Get("initializeForwarder") != "false" {
+			t.Fatalf("Forwarder zone should be created empty with initializeForwarder=false, got query: %s", r.URL.RawQuery)
+		}
+		if err := json.NewEncoder(w).Encode(APIResponse{
+			Status:   "ok",
+			Response: json.RawMessage(`{"domain":"."}`),
+		}); err != nil {
+			t.Fatalf("failed to encode response: %v", err)
+		}
+	})
+	defer ts.Close()
+
+	c, _ := NewClient(ClientConfig{BaseURL: ts.URL, Token: "test-token"})
+	domain, err := c.ZoneCreate(context.Background(), ".", "Forwarder", true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if domain != "." {
+		t.Fatalf("domain = %q, want .", domain)
+	}
+}
+
 func TestDoGet_Success(t *testing.T) {
 	ts := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Query().Get("token") != "test-token" {
@@ -350,9 +381,9 @@ func TestNewClient_CACertDir_Valid(t *testing.T) {
 	}
 
 	c, err := NewClient(ClientConfig{
-		BaseURL:    "https://localhost:5380",
-		Token:      "test-token",
-		CACertDir:  dir,
+		BaseURL:   "https://localhost:5380",
+		Token:     "test-token",
+		CACertDir: dir,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/internal/client/records.go
+++ b/internal/client/records.go
@@ -42,6 +42,7 @@ type RecordGetResponse struct {
 //   - PTR: "ptrName"
 //   - NS: "nameServer"
 //   - CAA: "flags", "tag", "value"
+//   - FWD: "protocol", "forwarder", "forwarderPriority", "dnssecValidation"
 func (c *Client) RecordAdd(ctx context.Context, domain, zone, recordType string, ttl int, overwrite bool, params map[string]string) (*Record, error) {
 	qp := url.Values{
 		"domain": {domain},
@@ -127,6 +128,7 @@ func (c *Client) RecordUpdate(ctx context.Context, domain, zone, recordType stri
 //   - PTR: "ptrName"
 //   - NS: "nameServer"
 //   - CAA: "flags", "tag", "value"
+//   - FWD: "protocol", "forwarder", "forwarderPriority", "dnssecValidation"
 func (c *Client) RecordDelete(ctx context.Context, domain, zone, recordType string, params map[string]string) error {
 	qp := url.Values{
 		"domain": {domain},
@@ -164,6 +166,8 @@ func RecordValueParam(recordType string) string {
 		return "nameServer"
 	case "CAA":
 		return "value"
+	case "FWD":
+		return "forwarder"
 	default:
 		return "value"
 	}

--- a/internal/client/records.go
+++ b/internal/client/records.go
@@ -98,6 +98,17 @@ func (c *Client) RecordGet(ctx context.Context, domain, zone string) ([]Record, 
 // For CNAME: "cname" (new value)
 // For MX: "exchange" (current), "newExchange" (new), "preference", "newPreference"
 // etc.
+//
+// 🚩 The current/new pairing does NOT extend to every field. FWD records have
+// "forwarder"/"newForwarder", "protocol"/"newProtocol" and
+// "forwarderPriority"/"newForwarderPriority", but "dnssecValidation" has no
+// "new" counterpart — it is the new value, and the old one cannot be supplied
+// as an identifier. Two FWD records differing only by that flag therefore
+// cannot be updated independently: the update rewrites one onto the other and
+// they collapse into a single record, reported as status "ok". Omitting
+// "dnssecValidation" entirely is also not "leave unchanged" — it resets the
+// record to false. Both verified on Technitium 15.2 and 15.4 and reported
+// upstream as TechnitiumSoftware/DnsServer#2069.
 func (c *Client) RecordUpdate(ctx context.Context, domain, zone, recordType string, ttl int, params map[string]string) error {
 	qp := url.Values{
 		"domain": {domain},
@@ -129,6 +140,13 @@ func (c *Client) RecordUpdate(ctx context.Context, domain, zone, recordType stri
 //   - NS: "nameServer"
 //   - CAA: "flags", "tag", "value"
 //   - FWD: "protocol", "forwarder", "forwarderPriority", "dnssecValidation"
+//
+// 🚩 "dnssecValidation" appears above because the provider sends it, NOT because
+// the server matches on it. Technitium 15.2 and 15.4 ignore it when selecting
+// which record to delete: given two FWD records identical apart from that flag,
+// the first-created one is removed whatever value is supplied, and the call
+// still returns status "ok". Do not assume this call can target one of a
+// colliding pair. Reported upstream as TechnitiumSoftware/DnsServer#2069.
 func (c *Client) RecordDelete(ctx context.Context, domain, zone, recordType string, params map[string]string) error {
 	qp := url.Values{
 		"domain": {domain},

--- a/internal/client/records_test.go
+++ b/internal/client/records_test.go
@@ -1,0 +1,19 @@
+// Copyright (c) 2026 Alex Ackerman
+// SPDX-License-Identifier: MPL-2.0
+
+package client
+
+import "testing"
+
+func TestRecordValueParam_FWD(t *testing.T) {
+	if got := RecordValueParam("FWD"); got != "forwarder" {
+		t.Fatalf("RecordValueParam(FWD) = %q, want forwarder", got)
+	}
+}
+
+func TestRecordValueFromRData_FWD(t *testing.T) {
+	rdata := map[string]interface{}{"forwarder": "dns.quad9.net:853 (9.9.9.9)"}
+	if got := RecordValueFromRData("FWD", rdata); got != "dns.quad9.net:853 (9.9.9.9)" {
+		t.Fatalf("RecordValueFromRData(FWD) = %q", got)
+	}
+}

--- a/internal/client/zones.go
+++ b/internal/client/zones.go
@@ -95,6 +95,12 @@ func (c *Client) ZoneCreate(ctx context.Context, name, zoneType string, useSoaSe
 	if useSoaSerialDateScheme {
 		params.Set("useSoaSerialDateScheme", "true")
 	}
+	if zoneType == "Forwarder" {
+		// Technitium initializes Forwarder zones with a required FWD record by
+		// default. Create an empty Forwarder zone so FWD records can be managed
+		// declaratively as separate technitium_record resources.
+		params.Set("initializeForwarder", "false")
+	}
 
 	resp, err := c.doGet(ctx, "/api/zones/create", params)
 	if err != nil {
@@ -106,6 +112,9 @@ func (c *Client) ZoneCreate(ctx context.Context, name, zoneType string, useSoaSe
 	}
 	if err := json.Unmarshal(resp.Response, &result); err != nil {
 		return "", fmt.Errorf("parsing create zone response: %w", err)
+	}
+	if result.Domain == "" {
+		return name, nil
 	}
 
 	return result.Domain, nil
@@ -267,7 +276,7 @@ func (c *Client) ZoneExists(ctx context.Context, name string) (bool, error) {
 		return false, err
 	}
 	for _, z := range zones {
-		if strings.EqualFold(z.Name, name) {
+		if strings.EqualFold(z.Name, name) || (name == "." && z.Name == "") {
 			return true, nil
 		}
 	}

--- a/internal/provider/inputvalidation/dns_record.go
+++ b/internal/provider/inputvalidation/dns_record.go
@@ -11,7 +11,7 @@ import (
 // validRecordTypes is the set of record types supported by the provider.
 var validRecordTypes = map[string]bool{
 	"A": true, "AAAA": true, "CNAME": true, "MX": true,
-	"NS": true, "PTR": true, "SRV": true, "TXT": true, "CAA": true,
+	"NS": true, "PTR": true, "SRV": true, "TXT": true, "CAA": true, "FWD": true,
 }
 
 // registerRecordRules adds all DNS record validation rules to the registry.
@@ -26,6 +26,7 @@ func registerRecordRules(r *Registry) {
 	r.Register(validatePTRRecord())
 	r.Register(validateSRVRecord())
 	r.Register(validateCAARecord())
+	r.Register(validateFWDRecord())
 }
 
 // DefaultRegistry returns a registry pre-loaded with all built-in validation rules.
@@ -42,7 +43,7 @@ func DefaultRegistry() *Registry {
 func validateRecordType() ValidationRule {
 	return ValidationRule{
 		Name:        "record_type",
-		Description: "Validates the record type is one of the 9 supported types",
+		Description: "Validates the record type is one of the supported types",
 		Resource:    ResourceRecord,
 		Validate: func(ctx context.Context, config ConfigAccessor) []Finding {
 			rt, ok := config.GetString("type")
@@ -53,7 +54,7 @@ func validateRecordType() ValidationRule {
 				return []Finding{{
 					Attribute: "type",
 					Summary:   fmt.Sprintf("Invalid record type: %q", rt),
-					Detail:    "Supported record types are: A, AAAA, CNAME, MX, NS, PTR, SRV, TXT, CAA (case-sensitive).",
+					Detail:    "Supported record types are: A, AAAA, CNAME, MX, NS, PTR, SRV, TXT, CAA, FWD (case-sensitive).",
 				}}
 			}
 			return nil
@@ -405,6 +406,57 @@ func validateCAARecord() ValidationRule {
 					Attribute: "value",
 					Summary:   "Invalid CAA record value: value must not be empty",
 					Detail:    `CAA records require a non-empty value (e.g., "letsencrypt.org").`,
+				})
+			}
+
+			return findings
+		},
+	}
+}
+
+// ---------------------------------------------------------------------------
+// FWD record
+// ---------------------------------------------------------------------------
+
+var validFWDProtocols = map[string]bool{
+	"Udp": true, "Tcp": true, "Tls": true, "Https": true, "Quic": true,
+}
+
+func validateFWDRecord() ValidationRule {
+	return ValidationRule{
+		Name:        "fwd_record",
+		Description: "FWD record: value must be non-empty and protocol must be valid",
+		Resource:    ResourceRecord,
+		Validate: func(ctx context.Context, config ConfigAccessor) []Finding {
+			rt, ok := config.GetString("type")
+			if !ok || rt != "FWD" {
+				return nil
+			}
+			var findings []Finding
+
+			value, ok := config.GetString("value")
+			if ok && value == "" {
+				findings = append(findings, Finding{
+					Attribute: "value",
+					Summary:   "Invalid FWD record value: forwarder address must not be empty",
+					Detail:    `FWD records require a forwarder address such as "1.1.1.1" or "dns.quad9.net:853 (9.9.9.9)".`,
+				})
+			}
+
+			protocol, hasProtocol := config.GetString("protocol")
+			if hasProtocol && protocol != "" && !validFWDProtocols[protocol] {
+				findings = append(findings, Finding{
+					Attribute: "protocol",
+					Summary:   fmt.Sprintf("Invalid FWD record protocol: %q is not supported", protocol),
+					Detail:    `FWD record protocol must be one of: "Udp", "Tcp", "Tls", "Https", "Quic".`,
+				})
+			}
+
+			if priority, hasPriority := config.GetInt64("forwarder_priority"); hasPriority && priority < 0 {
+				findings = append(findings, Finding{
+					Attribute: "forwarder_priority",
+					Summary:   fmt.Sprintf("Invalid FWD record forwarder_priority: %d is negative", priority),
+					Detail:    "FWD record forwarder_priority must be zero or greater; lower values are queried first.",
 				})
 			}
 

--- a/internal/provider/inputvalidation/dns_record_test.go
+++ b/internal/provider/inputvalidation/dns_record_test.go
@@ -11,7 +11,7 @@ import (
 // --- Record type validator ---
 
 func TestValidateRecordType_Valid(t *testing.T) {
-	validTypes := []string{"A", "AAAA", "CNAME", "MX", "NS", "PTR", "SRV", "TXT", "CAA"}
+	validTypes := []string{"A", "AAAA", "CNAME", "MX", "NS", "PTR", "SRV", "TXT", "CAA", "FWD"}
 	for _, rt := range validTypes {
 		t.Run(rt, func(t *testing.T) {
 			m := NewMockAccessor(map[string]interface{}{"type": rt})
@@ -44,6 +44,39 @@ func TestValidateRecordType_Missing(t *testing.T) {
 	findings := rule.Validate(context.Background(), m)
 	if len(findings) != 0 {
 		t.Errorf("expected 0 findings for missing type, got %d", len(findings))
+	}
+}
+
+func TestValidateFWDRecord_Valid(t *testing.T) {
+	m := NewMockAccessor(map[string]interface{}{
+		"type": "FWD", "value": "dns.quad9.net:853 (9.9.9.9)", "protocol": "Tls", "forwarder_priority": int64(1),
+	})
+	rule := validateFWDRecord()
+	findings := rule.Validate(context.Background(), m)
+	if len(findings) != 0 {
+		t.Fatalf("FWD record validator returned findings: %#v", findings)
+	}
+}
+
+func TestValidateFWDRecord_InvalidProtocol(t *testing.T) {
+	m := NewMockAccessor(map[string]interface{}{
+		"type": "FWD", "value": "1.1.1.1", "protocol": "Bogus", "forwarder_priority": int64(1),
+	})
+	rule := validateFWDRecord()
+	findings := rule.Validate(context.Background(), m)
+	if len(findings) != 1 {
+		t.Fatalf("expected 1 finding for invalid FWD protocol, got %d", len(findings))
+	}
+}
+
+func TestValidateFWDRecord_EmptyForwarder(t *testing.T) {
+	m := NewMockAccessor(map[string]interface{}{
+		"type": "FWD", "value": "", "protocol": "Udp", "forwarder_priority": int64(1),
+	})
+	rule := validateFWDRecord()
+	findings := rule.Validate(context.Background(), m)
+	if len(findings) != 1 {
+		t.Fatalf("expected 1 finding for empty FWD forwarder, got %d", len(findings))
 	}
 }
 

--- a/internal/provider/inputvalidation/engine_test.go
+++ b/internal/provider/inputvalidation/engine_test.go
@@ -193,6 +193,7 @@ func TestDefaultRegistry_HasAllRecordRules(t *testing.T) {
 		"srv_record":          false,
 		"txt_record_nonempty": false,
 		"caa_record":          false,
+		"fwd_record":          false,
 	}
 
 	for _, rule := range rules {

--- a/internal/provider/record_data_source.go
+++ b/internal/provider/record_data_source.go
@@ -24,13 +24,13 @@ type RecordDataSource struct {
 }
 
 type RecordDataSourceModel struct {
-	ID       types.String          `tfsdk:"id"`
-	Zone     types.String          `tfsdk:"zone"`
-	Name     types.String          `tfsdk:"name"`
-	Type     types.String          `tfsdk:"type"`
-	Value    types.String          `tfsdk:"value"`
-	TTL      types.Int64           `tfsdk:"ttl"`
-	Records  []RecordDataItemModel `tfsdk:"records"`
+	ID      types.String          `tfsdk:"id"`
+	Zone    types.String          `tfsdk:"zone"`
+	Name    types.String          `tfsdk:"name"`
+	Type    types.String          `tfsdk:"type"`
+	Value   types.String          `tfsdk:"value"`
+	TTL     types.Int64           `tfsdk:"ttl"`
+	Records []RecordDataItemModel `tfsdk:"records"`
 }
 
 type RecordDataItemModel struct {

--- a/internal/provider/record_id.go
+++ b/internal/provider/record_id.go
@@ -48,7 +48,7 @@ func buildRecordID(model *RecordResourceModel) string {
 			model.CAATag.ValueString(),
 		)
 	case "FWD":
-		valueSegment = fmt.Sprintf("%s:%s:%d", value, model.Protocol.ValueString(), model.ForwarderPriority.ValueInt64())
+		valueSegment = fmt.Sprintf("%s:%s:%d:%t", value, model.Protocol.ValueString(), model.ForwarderPriority.ValueInt64(), model.DNSSECValidation.ValueBool())
 	default:
 		valueSegment = value
 	}
@@ -133,11 +133,15 @@ func parseImportValueSegment(recordType, valueSegment string) (
 		parts := strings.Split(valueSegment, ":")
 		if len(parts) < 3 {
 			return "", 0, 0, 0, 0, "", fmt.Errorf(
-				"invalid FWD value segment %q: expected format forwarder:protocol:priority", valueSegment)
+				"invalid FWD value segment %q: expected format forwarder:protocol:priority[:dnssecValidation]", valueSegment)
 		}
-		priorityStr := parts[len(parts)-1]
-		protocol := parts[len(parts)-2]
-		forwarder := strings.Join(parts[:len(parts)-2], ":")
+		priorityIdx := len(parts) - 1
+		if parts[len(parts)-1] == "true" || parts[len(parts)-1] == "false" {
+			priorityIdx = len(parts) - 2
+		}
+		priorityStr := parts[priorityIdx]
+		protocol := parts[priorityIdx-1]
+		forwarder := strings.Join(parts[:priorityIdx-1], ":")
 		p, parseErr := strconv.ParseInt(priorityStr, 10, 64)
 		if parseErr != nil {
 			return "", 0, 0, 0, 0, "", fmt.Errorf(
@@ -240,6 +244,11 @@ func recordMatchesState(rec client.Record, state *RecordResourceModel) bool {
 			}
 		} else if priority, ok := rec.RData["priority"]; ok && !state.ForwarderPriority.IsNull() {
 			if int64(toFloat64(priority)) != state.ForwarderPriority.ValueInt64() {
+				return false
+			}
+		}
+		if dnssec, ok := rec.RData["dnssecValidation"]; ok && !state.DNSSECValidation.IsNull() {
+			if (int64(toFloat64(dnssec)) != 0) != state.DNSSECValidation.ValueBool() {
 				return false
 			}
 		}

--- a/internal/provider/record_id.go
+++ b/internal/provider/record_id.go
@@ -248,7 +248,14 @@ func recordMatchesState(rec client.Record, state *RecordResourceModel) bool {
 			}
 		}
 		if dnssec, ok := rec.RData["dnssecValidation"]; ok && !state.DNSSECValidation.IsNull() {
-			if (int64(toFloat64(dnssec)) != 0) != state.DNSSECValidation.ValueBool() {
+			var apiDNSSEC bool
+			switch v := dnssec.(type) {
+			case bool:
+				apiDNSSEC = v
+			default:
+				apiDNSSEC = toFloat64(v) != 0
+			}
+			if apiDNSSEC != state.DNSSECValidation.ValueBool() {
 				return false
 			}
 		}

--- a/internal/provider/record_id.go
+++ b/internal/provider/record_id.go
@@ -23,6 +23,7 @@ const recordIDSeparator = "::"
 //   - MX: zone::name::MX::exchange:priority
 //   - SRV: zone::name::SRV::target:priority:weight:port
 //   - CAA: zone::name::CAA::value:flags:tag
+//   - FWD: zone::name::FWD::forwarder:protocol:priority
 func buildRecordID(model *RecordResourceModel) string {
 	zone := model.Zone.ValueString()
 	name := model.Name.ValueString()
@@ -46,6 +47,8 @@ func buildRecordID(model *RecordResourceModel) string {
 			model.CAAFlags.ValueInt64(),
 			model.CAATag.ValueString(),
 		)
+	case "FWD":
+		valueSegment = fmt.Sprintf("%s:%s:%d", value, model.Protocol.ValueString(), model.ForwarderPriority.ValueInt64())
 	default:
 		valueSegment = value
 	}
@@ -74,6 +77,7 @@ func parseRecordID(id string) (zone, name, recordType, valueSegment string, err 
 //   - MX: exchange:priority (parsed from right via LastIndex)
 //   - SRV: target:priority:weight:port (last 3 fields numeric, rest is target)
 //   - CAA: value:flags:tag (last 2 fields are flags+tag, rest is value)
+//   - FWD: forwarder:protocol:priority (last 2 fields are protocol+priority)
 //   - Simple types: entire segment is the value
 func parseImportValueSegment(recordType, valueSegment string) (
 	value string, priority, weight, port, caaFlags int64, caaTag string, err error,
@@ -125,6 +129,22 @@ func parseImportValueSegment(recordType, valueSegment string) (
 		}
 		return target, p, w, pt, 0, "", nil
 
+	case "FWD":
+		parts := strings.Split(valueSegment, ":")
+		if len(parts) < 3 {
+			return "", 0, 0, 0, 0, "", fmt.Errorf(
+				"invalid FWD value segment %q: expected format forwarder:protocol:priority", valueSegment)
+		}
+		priorityStr := parts[len(parts)-1]
+		protocol := parts[len(parts)-2]
+		forwarder := strings.Join(parts[:len(parts)-2], ":")
+		p, parseErr := strconv.ParseInt(priorityStr, 10, 64)
+		if parseErr != nil {
+			return "", 0, 0, 0, 0, "", fmt.Errorf(
+				"invalid FWD priority in %q: %w", valueSegment, parseErr)
+		}
+		return forwarder, p, 0, 0, 0, protocol, nil
+
 	case "CAA":
 		// Format: value:flags:tag
 		// Parse from the right: last field is tag, second-to-last is flags.
@@ -158,6 +178,7 @@ func parseImportValueSegment(recordType, valueSegment string) (
 //   - MX: also match on preference (rData "preference") vs state.Priority
 //   - SRV: also match on priority, weight, port rData fields
 //   - CAA: also match on flags, tag rData fields
+//   - FWD: also match on protocol and priority/forwarderPriority rData fields
 func recordMatchesState(rec client.Record, state *RecordResourceModel) bool {
 	recordType := state.Type.ValueString()
 
@@ -204,6 +225,21 @@ func recordMatchesState(rec client.Record, state *RecordResourceModel) bool {
 		}
 		if tag, ok := rec.RData["tag"]; ok {
 			if fmt.Sprintf("%v", tag) != state.CAATag.ValueString() {
+				return false
+			}
+		}
+	case "FWD":
+		if protocol, ok := rec.RData["protocol"]; ok && !state.Protocol.IsNull() {
+			if fmt.Sprintf("%v", protocol) != state.Protocol.ValueString() {
+				return false
+			}
+		}
+		if priority, ok := rec.RData["forwarderPriority"]; ok && !state.ForwarderPriority.IsNull() {
+			if int64(toFloat64(priority)) != state.ForwarderPriority.ValueInt64() {
+				return false
+			}
+		} else if priority, ok := rec.RData["priority"]; ok && !state.ForwarderPriority.IsNull() {
+			if int64(toFloat64(priority)) != state.ForwarderPriority.ValueInt64() {
 				return false
 			}
 		}

--- a/internal/provider/record_id.go
+++ b/internal/provider/record_id.go
@@ -23,7 +23,12 @@ const recordIDSeparator = "::"
 //   - MX: zone::name::MX::exchange:priority
 //   - SRV: zone::name::SRV::target:priority:weight:port
 //   - CAA: zone::name::CAA::value:flags:tag
-//   - FWD: zone::name::FWD::forwarder:protocol:priority
+//   - FWD: zone::name::FWD::forwarder:protocol:priority:dnssecValidation
+//
+// The FWD form carries dnssecValidation because forwarder/protocol/priority
+// alone do not uniquely identify a record — two forwarders may differ only by
+// that flag. parseImportValueSegment still accepts the legacy 3-field form, so
+// IDs generated before this existed continue to import.
 func buildRecordID(model *RecordResourceModel) string {
 	zone := model.Zone.ValueString()
 	name := model.Name.ValueString()

--- a/internal/provider/record_id.go
+++ b/internal/provider/record_id.go
@@ -70,6 +70,32 @@ func parseRecordID(id string) (zone, name, recordType, valueSegment string, err 
 	return parts[0], parts[1], parts[2], parts[3], nil
 }
 
+// importValueFields holds the type-specific fields decoded from the value
+// segment of a composite import ID.
+//
+// This is a named struct rather than a list of positional returns on purpose.
+// The previous signature returned a single shared string slot that CAA used for
+// its tag and FWD reused for its protocol, so ImportState read a variable named
+// caaTag and wrote it straight into the protocol attribute. That worked only by
+// coincidence of the two types sharing a slot, and it is exactly the kind of
+// thing that regresses silently when a new record type is added.
+type importValueFields struct {
+	Value    string
+	Priority int64
+	Weight   int64
+	Port     int64
+	CAAFlags int64
+	// CAATag is set for CAA records only.
+	CAATag string
+	// Protocol is set for FWD records only.
+	Protocol string
+	// DNSSECValidation is set for FWD records only, and is nil when the legacy
+	// 3-field form (forwarder:protocol:priority) was used. nil therefore means
+	// "the import ID did not state it", which is distinct from an explicit
+	// false — the caller must not set the attribute in that case.
+	DNSSECValidation *bool
+}
+
 // parseImportValueSegment extracts value and type-specific fields from the
 // value segment of an import ID.
 //
@@ -77,99 +103,108 @@ func parseRecordID(id string) (zone, name, recordType, valueSegment string, err 
 //   - MX: exchange:priority (parsed from right via LastIndex)
 //   - SRV: target:priority:weight:port (last 3 fields numeric, rest is target)
 //   - CAA: value:flags:tag (last 2 fields are flags+tag, rest is value)
-//   - FWD: forwarder:protocol:priority (last 2 fields are protocol+priority)
+//   - FWD: forwarder:protocol:priority[:dnssecValidation] (parsed from the
+//     right; the trailing dnssec field is optional for backward compatibility
+//     with IDs generated before it was part of the identity)
 //   - Simple types: entire segment is the value
-func parseImportValueSegment(recordType, valueSegment string) (
-	value string, priority, weight, port, caaFlags int64, caaTag string, err error,
-) {
+//
+// Parsing from the right matters for FWD: a forwarder may itself contain
+// colons (an IPv6 address, or a DoH URL such as
+// https://cloudflare-dns.com/dns-query), so the leading fields are rejoined.
+func parseImportValueSegment(recordType, valueSegment string) (importValueFields, error) {
+	fail := func(format string, args ...any) (importValueFields, error) {
+		return importValueFields{}, fmt.Errorf(format, args...)
+	}
+
 	switch recordType {
 	case "MX":
 		idx := strings.LastIndex(valueSegment, ":")
 		if idx < 0 {
-			return "", 0, 0, 0, 0, "", fmt.Errorf(
-				"invalid MX value segment %q: expected format exchange:priority", valueSegment)
+			return fail("invalid MX value segment %q: expected format exchange:priority", valueSegment)
 		}
-		value = valueSegment[:idx]
 		p, parseErr := strconv.ParseInt(valueSegment[idx+1:], 10, 64)
 		if parseErr != nil {
-			return "", 0, 0, 0, 0, "", fmt.Errorf(
-				"invalid MX priority in %q: %w", valueSegment, parseErr)
+			return fail("invalid MX priority in %q: %w", valueSegment, parseErr)
 		}
-		priority = p
-		return value, priority, 0, 0, 0, "", nil
+		return importValueFields{Value: valueSegment[:idx], Priority: p}, nil
 
 	case "SRV":
 		// Format: target:priority:weight:port
 		// Parse from the right: last 3 colon-separated fields are numeric.
 		parts := strings.Split(valueSegment, ":")
 		if len(parts) < 4 {
-			return "", 0, 0, 0, 0, "", fmt.Errorf(
-				"invalid SRV value segment %q: expected format target:priority:weight:port", valueSegment)
+			return fail("invalid SRV value segment %q: expected format target:priority:weight:port", valueSegment)
 		}
-		// Last 3 are priority, weight, port; everything before is the target.
-		portStr := parts[len(parts)-1]
-		weightStr := parts[len(parts)-2]
-		priorityStr := parts[len(parts)-3]
-		target := strings.Join(parts[:len(parts)-3], ":")
-
-		p, parseErr := strconv.ParseInt(priorityStr, 10, 64)
+		p, parseErr := strconv.ParseInt(parts[len(parts)-3], 10, 64)
 		if parseErr != nil {
-			return "", 0, 0, 0, 0, "", fmt.Errorf(
-				"invalid SRV priority in %q: %w", valueSegment, parseErr)
+			return fail("invalid SRV priority in %q: %w", valueSegment, parseErr)
 		}
-		w, parseErr := strconv.ParseInt(weightStr, 10, 64)
+		w, parseErr := strconv.ParseInt(parts[len(parts)-2], 10, 64)
 		if parseErr != nil {
-			return "", 0, 0, 0, 0, "", fmt.Errorf(
-				"invalid SRV weight in %q: %w", valueSegment, parseErr)
+			return fail("invalid SRV weight in %q: %w", valueSegment, parseErr)
 		}
-		pt, parseErr := strconv.ParseInt(portStr, 10, 64)
+		pt, parseErr := strconv.ParseInt(parts[len(parts)-1], 10, 64)
 		if parseErr != nil {
-			return "", 0, 0, 0, 0, "", fmt.Errorf(
-				"invalid SRV port in %q: %w", valueSegment, parseErr)
+			return fail("invalid SRV port in %q: %w", valueSegment, parseErr)
 		}
-		return target, p, w, pt, 0, "", nil
+		return importValueFields{
+			Value:    strings.Join(parts[:len(parts)-3], ":"),
+			Priority: p,
+			Weight:   w,
+			Port:     pt,
+		}, nil
 
 	case "FWD":
 		parts := strings.Split(valueSegment, ":")
 		if len(parts) < 3 {
-			return "", 0, 0, 0, 0, "", fmt.Errorf(
-				"invalid FWD value segment %q: expected format forwarder:protocol:priority[:dnssecValidation]", valueSegment)
+			return fail("invalid FWD value segment %q: expected format forwarder:protocol:priority[:dnssecValidation]", valueSegment)
 		}
+
+		// The trailing dnssec field is optional. Detect it by value rather than
+		// by field count: the forwarder may contain colons, so a count-based
+		// test cannot tell "4 fields because dnssec is present" from "4 fields
+		// because the forwarder had a colon in it".
+		var dnssec *bool
 		priorityIdx := len(parts) - 1
-		if parts[len(parts)-1] == "true" || parts[len(parts)-1] == "false" {
+		if last := parts[len(parts)-1]; last == "true" || last == "false" {
+			v := last == "true"
+			dnssec = &v
 			priorityIdx = len(parts) - 2
 		}
-		priorityStr := parts[priorityIdx]
-		protocol := parts[priorityIdx-1]
-		forwarder := strings.Join(parts[:priorityIdx-1], ":")
-		p, parseErr := strconv.ParseInt(priorityStr, 10, 64)
-		if parseErr != nil {
-			return "", 0, 0, 0, 0, "", fmt.Errorf(
-				"invalid FWD priority in %q: %w", valueSegment, parseErr)
+		if priorityIdx < 2 {
+			return fail("invalid FWD value segment %q: expected format forwarder:protocol:priority[:dnssecValidation]", valueSegment)
 		}
-		return forwarder, p, 0, 0, 0, protocol, nil
+
+		p, parseErr := strconv.ParseInt(parts[priorityIdx], 10, 64)
+		if parseErr != nil {
+			return fail("invalid FWD priority in %q: %w", valueSegment, parseErr)
+		}
+		return importValueFields{
+			Value:            strings.Join(parts[:priorityIdx-1], ":"),
+			Priority:         p,
+			Protocol:         parts[priorityIdx-1],
+			DNSSECValidation: dnssec,
+		}, nil
 
 	case "CAA":
 		// Format: value:flags:tag
 		// Parse from the right: last field is tag, second-to-last is flags.
 		parts := strings.Split(valueSegment, ":")
 		if len(parts) < 3 {
-			return "", 0, 0, 0, 0, "", fmt.Errorf(
-				"invalid CAA value segment %q: expected format value:flags:tag", valueSegment)
+			return fail("invalid CAA value segment %q: expected format value:flags:tag", valueSegment)
 		}
-		tag := parts[len(parts)-1]
-		flagsStr := parts[len(parts)-2]
-		val := strings.Join(parts[:len(parts)-2], ":")
-
-		f, parseErr := strconv.ParseInt(flagsStr, 10, 64)
+		f, parseErr := strconv.ParseInt(parts[len(parts)-2], 10, 64)
 		if parseErr != nil {
-			return "", 0, 0, 0, 0, "", fmt.Errorf(
-				"invalid CAA flags in %q: %w", valueSegment, parseErr)
+			return fail("invalid CAA flags in %q: %w", valueSegment, parseErr)
 		}
-		return val, 0, 0, 0, f, tag, nil
+		return importValueFields{
+			Value:    strings.Join(parts[:len(parts)-2], ":"),
+			CAAFlags: f,
+			CAATag:   parts[len(parts)-1],
+		}, nil
 
 	default:
-		return valueSegment, 0, 0, 0, 0, "", nil
+		return importValueFields{Value: valueSegment}, nil
 	}
 }
 

--- a/internal/provider/record_id_test.go
+++ b/internal/provider/record_id_test.go
@@ -140,6 +140,52 @@ func TestBuildRecordID_CAA(t *testing.T) {
 	}
 }
 
+func TestBuildRecordID_FWD(t *testing.T) {
+	model := RecordResourceModel{
+		Zone:              types.StringValue("."),
+		Name:              types.StringValue("."),
+		Type:              types.StringValue("FWD"),
+		Value:             types.StringValue("dns.quad9.net:853 (9.9.9.9)"),
+		Protocol:          types.StringValue("Tls"),
+		ForwarderPriority: types.Int64Value(1),
+	}
+	expected := ".::.::FWD::dns.quad9.net:853 (9.9.9.9):Tls:1"
+	got := buildRecordID(&model)
+	if got != expected {
+		t.Errorf("buildRecordID() = %q, want %q", got, expected)
+	}
+}
+
+func TestParseImportValueSegment_FWD(t *testing.T) {
+	value, priority, _, _, _, protocol, err := parseImportValueSegment("FWD", "dns.quad9.net:853 (9.9.9.9):Tls:1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if value != "dns.quad9.net:853 (9.9.9.9)" || protocol != "Tls" || priority != 1 {
+		t.Fatalf("parsed FWD = value %q protocol %q priority %d", value, protocol, priority)
+	}
+}
+
+func TestRecordMatchesState_FWD(t *testing.T) {
+	rec := client.Record{
+		Type: "FWD",
+		RData: map[string]interface{}{
+			"forwarder":         "1.1.1.1",
+			"protocol":          "Udp",
+			"forwarderPriority": float64(2),
+		},
+	}
+	state := RecordResourceModel{
+		Type:              types.StringValue("FWD"),
+		Value:             types.StringValue("1.1.1.1"),
+		Protocol:          types.StringValue("Udp"),
+		ForwarderPriority: types.Int64Value(2),
+	}
+	if !recordMatchesState(rec, &state) {
+		t.Fatal("expected FWD record to match state")
+	}
+}
+
 // ---------------------------------------------------------------------------
 // parseRecordID tests
 // ---------------------------------------------------------------------------

--- a/internal/provider/record_id_test.go
+++ b/internal/provider/record_id_test.go
@@ -149,10 +149,46 @@ func TestBuildRecordID_FWD(t *testing.T) {
 		Protocol:          types.StringValue("Tls"),
 		ForwarderPriority: types.Int64Value(1),
 	}
-	expected := ".::.::FWD::dns.quad9.net:853 (9.9.9.9):Tls:1"
+	expected := ".::.::FWD::dns.quad9.net:853 (9.9.9.9):Tls:1:false"
 	got := buildRecordID(&model)
 	if got != expected {
 		t.Errorf("buildRecordID() = %q, want %q", got, expected)
+	}
+}
+
+func TestBuildRecordID_FWD_DNSSEC(t *testing.T) {
+	tests := []struct {
+		name     string
+		dnssec   bool
+		expected string
+	}{
+		{
+			name:     "dnssec true",
+			dnssec:   true,
+			expected: ".::.::FWD::1.1.1.1:Udp:1:true",
+		},
+		{
+			name:     "dnssec false",
+			dnssec:   false,
+			expected: ".::.::FWD::1.1.1.1:Udp:1:false",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			model := RecordResourceModel{
+				Zone:              types.StringValue("."),
+				Name:              types.StringValue("."),
+				Type:              types.StringValue("FWD"),
+				Value:             types.StringValue("1.1.1.1"),
+				Protocol:          types.StringValue("Udp"),
+				ForwarderPriority: types.Int64Value(1),
+				DNSSECValidation:  types.BoolValue(tc.dnssec),
+			}
+			got := buildRecordID(&model)
+			if got != tc.expected {
+				t.Errorf("buildRecordID() = %q, want %q", got, tc.expected)
+			}
+		})
 	}
 }
 
@@ -163,6 +199,69 @@ func TestParseImportValueSegment_FWD(t *testing.T) {
 	}
 	if value != "dns.quad9.net:853 (9.9.9.9)" || protocol != "Tls" || priority != 1 {
 		t.Fatalf("parsed FWD = value %q protocol %q priority %d", value, protocol, priority)
+	}
+}
+
+func TestParseImportValueSegment_FWD_DNSSEC(t *testing.T) {
+	tests := []struct {
+		name            string
+		valueSegment    string
+		wantForwarder   string
+		wantProtocol    string
+		wantPriority    int64
+	}{
+		{
+			name:          "with dnssec true",
+			valueSegment:  "1.1.1.1:Udp:1:true",
+			wantForwarder: "1.1.1.1",
+			wantProtocol:  "Udp",
+			wantPriority:  1,
+		},
+		{
+			name:          "with dnssec false",
+			valueSegment:  "1.1.1.1:Udp:1:false",
+			wantForwarder: "1.1.1.1",
+			wantProtocol:  "Udp",
+			wantPriority:  1,
+		},
+		{
+			name:          "without dnssec (backward compat)",
+			valueSegment:  "1.1.1.1:Udp:1",
+			wantForwarder: "1.1.1.1",
+			wantProtocol:  "Udp",
+			wantPriority:  1,
+		},
+		{
+			name:          "forwarder with colon in name + dnssec",
+			valueSegment:  "dns.quad9.net:853 (9.9.9.9):Tls:1:true",
+			wantForwarder: "dns.quad9.net:853 (9.9.9.9)",
+			wantProtocol:  "Tls",
+			wantPriority:  1,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			value, priority, _, _, _, protocol, err := parseImportValueSegment("FWD", tc.valueSegment)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if value != tc.wantForwarder {
+				t.Errorf("value = %q, want %q", value, tc.wantForwarder)
+			}
+			if protocol != tc.wantProtocol {
+				t.Errorf("protocol = %q, want %q", protocol, tc.wantProtocol)
+			}
+			if priority != tc.wantPriority {
+				t.Errorf("priority = %d, want %d", priority, tc.wantPriority)
+			}
+		})
+	}
+}
+
+func TestParseImportValueSegment_FWD_Invalid(t *testing.T) {
+	_, _, _, _, _, _, err := parseImportValueSegment("FWD", "1.1.1.1:Udp")
+	if err == nil {
+		t.Error("expected error for FWD with too few fields")
 	}
 }
 
@@ -183,6 +282,66 @@ func TestRecordMatchesState_FWD(t *testing.T) {
 	}
 	if !recordMatchesState(rec, &state) {
 		t.Fatal("expected FWD record to match state")
+	}
+}
+
+func TestRecordMatchesState_FWD_DNSSEC(t *testing.T) {
+	tests := []struct {
+		name      string
+		recDNSSEC float64
+		stateDNSSEC bool
+		wantMatch bool
+	}{
+		{"both true", 1, true, true},
+		{"both false", 0, false, true},
+		{"rec true state false", 1, false, false},
+		{"rec false state true", 0, true, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := client.Record{
+				Type: "FWD",
+				RData: map[string]interface{}{
+					"forwarder":         "1.1.1.1",
+					"protocol":          "Udp",
+					"forwarderPriority": float64(1),
+					"dnssecValidation":  tc.recDNSSEC,
+				},
+			}
+			state := RecordResourceModel{
+				Type:              types.StringValue("FWD"),
+				Value:             types.StringValue("1.1.1.1"),
+				Protocol:          types.StringValue("Udp"),
+				ForwarderPriority: types.Int64Value(1),
+				DNSSECValidation:  types.BoolValue(tc.stateDNSSEC),
+			}
+			got := recordMatchesState(rec, &state)
+			if got != tc.wantMatch {
+				t.Errorf("recordMatchesState() = %v, want %v", got, tc.wantMatch)
+			}
+		})
+	}
+}
+
+func TestRecordMatchesState_FWD_DNSSEC_Mismatch(t *testing.T) {
+	rec := client.Record{
+		Type: "FWD",
+		RData: map[string]interface{}{
+			"forwarder":         "1.1.1.1",
+			"protocol":          "Udp",
+			"forwarderPriority": float64(1),
+			"dnssecValidation":  float64(1),
+		},
+	}
+	state := RecordResourceModel{
+		Type:              types.StringValue("FWD"),
+		Value:             types.StringValue("1.1.1.1"),
+		Protocol:          types.StringValue("Udp"),
+		ForwarderPriority: types.Int64Value(1),
+		DNSSECValidation:  types.BoolValue(false),
+	}
+	if recordMatchesState(rec, &state) {
+		t.Fatal("expected no match when dnssecValidation differs")
 	}
 }
 

--- a/internal/provider/record_id_test.go
+++ b/internal/provider/record_id_test.go
@@ -193,22 +193,29 @@ func TestBuildRecordID_FWD_DNSSEC(t *testing.T) {
 }
 
 func TestParseImportValueSegment_FWD(t *testing.T) {
-	value, priority, _, _, _, protocol, err := parseImportValueSegment("FWD", "dns.quad9.net:853 (9.9.9.9):Tls:1")
+	f, err := parseImportValueSegment("FWD", "dns.quad9.net:853 (9.9.9.9):Tls:1")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if value != "dns.quad9.net:853 (9.9.9.9)" || protocol != "Tls" || priority != 1 {
-		t.Fatalf("parsed FWD = value %q protocol %q priority %d", value, protocol, priority)
+	if f.Value != "dns.quad9.net:853 (9.9.9.9)" || f.Protocol != "Tls" || f.Priority != 1 {
+		t.Fatalf("parsed FWD = value %q protocol %q priority %d", f.Value, f.Protocol, f.Priority)
+	}
+	if f.DNSSECValidation != nil {
+		t.Errorf("legacy 3-field ID must leave DNSSECValidation nil, got %v", *f.DNSSECValidation)
 	}
 }
 
 func TestParseImportValueSegment_FWD_DNSSEC(t *testing.T) {
+	boolPtr := func(b bool) *bool { return &b }
 	tests := []struct {
-		name            string
-		valueSegment    string
-		wantForwarder   string
-		wantProtocol    string
-		wantPriority    int64
+		name          string
+		valueSegment  string
+		wantForwarder string
+		wantProtocol  string
+		wantPriority  int64
+		// nil means the ID did not state dnssec (legacy 3-field form), which is
+		// distinct from an explicit false.
+		wantDNSSEC *bool
 	}{
 		{
 			name:          "with dnssec true",
@@ -216,6 +223,7 @@ func TestParseImportValueSegment_FWD_DNSSEC(t *testing.T) {
 			wantForwarder: "1.1.1.1",
 			wantProtocol:  "Udp",
 			wantPriority:  1,
+			wantDNSSEC:    boolPtr(true),
 		},
 		{
 			name:          "with dnssec false",
@@ -223,6 +231,7 @@ func TestParseImportValueSegment_FWD_DNSSEC(t *testing.T) {
 			wantForwarder: "1.1.1.1",
 			wantProtocol:  "Udp",
 			wantPriority:  1,
+			wantDNSSEC:    boolPtr(false),
 		},
 		{
 			name:          "without dnssec (backward compat)",
@@ -230,6 +239,7 @@ func TestParseImportValueSegment_FWD_DNSSEC(t *testing.T) {
 			wantForwarder: "1.1.1.1",
 			wantProtocol:  "Udp",
 			wantPriority:  1,
+			wantDNSSEC:    nil,
 		},
 		{
 			name:          "forwarder with colon in name + dnssec",
@@ -237,29 +247,57 @@ func TestParseImportValueSegment_FWD_DNSSEC(t *testing.T) {
 			wantForwarder: "dns.quad9.net:853 (9.9.9.9)",
 			wantProtocol:  "Tls",
 			wantPriority:  1,
+			wantDNSSEC:    boolPtr(true),
+		},
+		{
+			// A DoH forwarder contains "://", so a count-based field test would
+			// misread this. Parsing from the right must still recover all four
+			// fields intact.
+			name:          "DoH URL forwarder + dnssec",
+			valueSegment:  "https://cloudflare-dns.com/dns-query:Https:1:true",
+			wantForwarder: "https://cloudflare-dns.com/dns-query",
+			wantProtocol:  "Https",
+			wantPriority:  1,
+			wantDNSSEC:    boolPtr(true),
+		},
+		{
+			name:          "DoH URL forwarder, legacy 3-field",
+			valueSegment:  "https://dns.google/dns-query:Https:2",
+			wantForwarder: "https://dns.google/dns-query",
+			wantProtocol:  "Https",
+			wantPriority:  2,
+			wantDNSSEC:    nil,
 		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			value, priority, _, _, _, protocol, err := parseImportValueSegment("FWD", tc.valueSegment)
+			f, err := parseImportValueSegment("FWD", tc.valueSegment)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
-			if value != tc.wantForwarder {
-				t.Errorf("value = %q, want %q", value, tc.wantForwarder)
+			if f.Value != tc.wantForwarder {
+				t.Errorf("value = %q, want %q", f.Value, tc.wantForwarder)
 			}
-			if protocol != tc.wantProtocol {
-				t.Errorf("protocol = %q, want %q", protocol, tc.wantProtocol)
+			if f.Protocol != tc.wantProtocol {
+				t.Errorf("protocol = %q, want %q", f.Protocol, tc.wantProtocol)
 			}
-			if priority != tc.wantPriority {
-				t.Errorf("priority = %d, want %d", priority, tc.wantPriority)
+			if f.Priority != tc.wantPriority {
+				t.Errorf("priority = %d, want %d", f.Priority, tc.wantPriority)
+			}
+			switch {
+			case tc.wantDNSSEC == nil && f.DNSSECValidation != nil:
+				t.Errorf("DNSSECValidation = %v, want nil (legacy form must not fabricate a value)", *f.DNSSECValidation)
+			case tc.wantDNSSEC != nil && f.DNSSECValidation == nil:
+				t.Errorf("DNSSECValidation = nil, want %v", *tc.wantDNSSEC)
+			case tc.wantDNSSEC != nil && *f.DNSSECValidation != *tc.wantDNSSEC:
+				t.Errorf("DNSSECValidation = %v, want %v", *f.DNSSECValidation, *tc.wantDNSSEC)
 			}
 		})
 	}
 }
 
 func TestParseImportValueSegment_FWD_Invalid(t *testing.T) {
-	_, _, _, _, _, _, err := parseImportValueSegment("FWD", "1.1.1.1:Udp")
+	_, err := parseImportValueSegment("FWD", "1.1.1.1:Udp")
 	if err == nil {
 		t.Error("expected error for FWD with too few fields")
 	}
@@ -287,10 +325,10 @@ func TestRecordMatchesState_FWD(t *testing.T) {
 
 func TestRecordMatchesState_FWD_DNSSEC(t *testing.T) {
 	tests := []struct {
-		name      string
-		recDNSSEC float64
+		name        string
+		recDNSSEC   float64
 		stateDNSSEC bool
-		wantMatch bool
+		wantMatch   bool
 	}{
 		{"both true", 1, true, true},
 		{"both false", 0, false, true},
@@ -464,7 +502,8 @@ func TestParseImportValueSegment_SimpleTypes(t *testing.T) {
 	simpleTypes := []string{"A", "AAAA", "CNAME", "TXT", "PTR", "NS"}
 	for _, rt := range simpleTypes {
 		t.Run(rt, func(t *testing.T) {
-			value, priority, weight, port, caaFlags, caaTag, err := parseImportValueSegment(rt, "some-value")
+			f, err := parseImportValueSegment(rt, "some-value")
+			value, priority, weight, port, caaFlags, caaTag := f.Value, f.Priority, f.Weight, f.Port, f.CAAFlags, f.CAATag
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
@@ -479,7 +518,8 @@ func TestParseImportValueSegment_SimpleTypes(t *testing.T) {
 }
 
 func TestParseImportValueSegment_MX(t *testing.T) {
-	value, priority, weight, port, caaFlags, caaTag, err := parseImportValueSegment("MX", "mail.example.com:10")
+	f, err := parseImportValueSegment("MX", "mail.example.com:10")
+	value, priority, weight, port, caaFlags, caaTag := f.Value, f.Priority, f.Weight, f.Port, f.CAAFlags, f.CAATag
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -495,21 +535,22 @@ func TestParseImportValueSegment_MX(t *testing.T) {
 }
 
 func TestParseImportValueSegment_MX_InvalidPriority(t *testing.T) {
-	_, _, _, _, _, _, err := parseImportValueSegment("MX", "mail.example.com:abc")
+	_, err := parseImportValueSegment("MX", "mail.example.com:abc")
 	if err == nil {
 		t.Error("expected error for non-numeric priority")
 	}
 }
 
 func TestParseImportValueSegment_MX_NoColon(t *testing.T) {
-	_, _, _, _, _, _, err := parseImportValueSegment("MX", "mail.example.com")
+	_, err := parseImportValueSegment("MX", "mail.example.com")
 	if err == nil {
 		t.Error("expected error for MX without priority")
 	}
 }
 
 func TestParseImportValueSegment_SRV(t *testing.T) {
-	value, priority, weight, port, caaFlags, caaTag, err := parseImportValueSegment("SRV", "sip.example.com:10:60:5060")
+	f, err := parseImportValueSegment("SRV", "sip.example.com:10:60:5060")
+	value, priority, weight, port, caaFlags, caaTag := f.Value, f.Priority, f.Weight, f.Port, f.CAAFlags, f.CAATag
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -531,21 +572,22 @@ func TestParseImportValueSegment_SRV(t *testing.T) {
 }
 
 func TestParseImportValueSegment_SRV_TooFewFields(t *testing.T) {
-	_, _, _, _, _, _, err := parseImportValueSegment("SRV", "sip.example.com:10:60")
+	_, err := parseImportValueSegment("SRV", "sip.example.com:10:60")
 	if err == nil {
 		t.Error("expected error for SRV with too few colon-separated fields")
 	}
 }
 
 func TestParseImportValueSegment_SRV_InvalidNumeric(t *testing.T) {
-	_, _, _, _, _, _, err := parseImportValueSegment("SRV", "sip.example.com:abc:60:5060")
+	_, err := parseImportValueSegment("SRV", "sip.example.com:abc:60:5060")
 	if err == nil {
 		t.Error("expected error for SRV with non-numeric priority")
 	}
 }
 
 func TestParseImportValueSegment_CAA(t *testing.T) {
-	value, priority, weight, port, caaFlags, caaTag, err := parseImportValueSegment("CAA", "letsencrypt.org:0:issue")
+	f, err := parseImportValueSegment("CAA", "letsencrypt.org:0:issue")
+	value, priority, weight, port, caaFlags, caaTag := f.Value, f.Priority, f.Weight, f.Port, f.CAAFlags, f.CAATag
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -564,7 +606,8 @@ func TestParseImportValueSegment_CAA(t *testing.T) {
 }
 
 func TestParseImportValueSegment_CAA_CriticalFlag(t *testing.T) {
-	value, _, _, _, caaFlags, caaTag, err := parseImportValueSegment("CAA", "ca.example.com:128:issuewild")
+	f, err := parseImportValueSegment("CAA", "ca.example.com:128:issuewild")
+	value, caaFlags, caaTag := f.Value, f.CAAFlags, f.CAATag
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -580,7 +623,7 @@ func TestParseImportValueSegment_CAA_CriticalFlag(t *testing.T) {
 }
 
 func TestParseImportValueSegment_CAA_TooFewFields(t *testing.T) {
-	_, _, _, _, _, _, err := parseImportValueSegment("CAA", "letsencrypt.org:0")
+	_, err := parseImportValueSegment("CAA", "letsencrypt.org:0")
 	if err == nil {
 		t.Error("expected error for CAA with too few colon-separated fields")
 	}

--- a/internal/provider/record_resource.go
+++ b/internal/provider/record_resource.go
@@ -440,6 +440,10 @@ func (r *RecordResource) ImportState(ctx context.Context, req resource.ImportSta
 	if recordType == "FWD" {
 		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("protocol"), caaTag)...)
 		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("forwarder_priority"), priority)...)
+		parts := strings.Split(valueSegment, ":")
+		if len(parts) >= 4 && (parts[len(parts)-1] == "true" || parts[len(parts)-1] == "false") {
+			resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("dnssec_validation"), parts[len(parts)-1] == "true")...)
+		}
 	}
 }
 

--- a/internal/provider/record_resource.go
+++ b/internal/provider/record_resource.go
@@ -41,18 +41,26 @@ type RecordResource struct {
 }
 
 type RecordResourceModel struct {
-	ID        types.String `tfsdk:"id"`
-	Zone      types.String `tfsdk:"zone"`
-	Name      types.String `tfsdk:"name"`
-	Type      types.String `tfsdk:"type"`
-	TTL       types.Int64  `tfsdk:"ttl"`
-	Value     types.String `tfsdk:"value"`
-	Priority  types.Int64  `tfsdk:"priority"`
-	Weight    types.Int64  `tfsdk:"weight"`
-	Port      types.Int64  `tfsdk:"port"`
-	CAAFlags  types.Int64  `tfsdk:"caa_flags"`
-	CAATag    types.String `tfsdk:"caa_tag"`
-	Overwrite types.Bool   `tfsdk:"overwrite"`
+	ID                types.String `tfsdk:"id"`
+	Zone              types.String `tfsdk:"zone"`
+	Name              types.String `tfsdk:"name"`
+	Type              types.String `tfsdk:"type"`
+	TTL               types.Int64  `tfsdk:"ttl"`
+	Value             types.String `tfsdk:"value"`
+	Priority          types.Int64  `tfsdk:"priority"`
+	Weight            types.Int64  `tfsdk:"weight"`
+	Port              types.Int64  `tfsdk:"port"`
+	CAAFlags          types.Int64  `tfsdk:"caa_flags"`
+	CAATag            types.String `tfsdk:"caa_tag"`
+	Protocol          types.String `tfsdk:"protocol"`
+	ForwarderPriority types.Int64  `tfsdk:"forwarder_priority"`
+	DNSSECValidation  types.Bool   `tfsdk:"dnssec_validation"`
+	ProxyType         types.String `tfsdk:"proxy_type"`
+	ProxyAddress      types.String `tfsdk:"proxy_address"`
+	ProxyPort         types.Int64  `tfsdk:"proxy_port"`
+	ProxyUsername     types.String `tfsdk:"proxy_username"`
+	ProxyPassword     types.String `tfsdk:"proxy_password"`
+	Overwrite         types.Bool   `tfsdk:"overwrite"`
 	// Computed
 	LastModified types.String `tfsdk:"last_modified"`
 }
@@ -84,7 +92,7 @@ func (r *RecordResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 				},
 			},
 			"type": schema.StringAttribute{
-				Description: "DNS record type: A, AAAA, CNAME, MX, TXT, SRV, PTR, NS, CAA.",
+				Description: "DNS record type: A, AAAA, CNAME, MX, TXT, SRV, PTR, NS, CAA, FWD.",
 				Required:    true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
@@ -97,7 +105,7 @@ func (r *RecordResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 				Default:     int64default.StaticInt64(3600),
 			},
 			"value": schema.StringAttribute{
-				Description: "Record data. For A/AAAA: IP address. For CNAME: target domain. For MX: exchange domain. For TXT: text data. For SRV: target. For PTR: domain name. For NS: nameserver. For CAA: value.",
+				Description: "Record data. For A/AAAA: IP address. For CNAME: target domain. For MX: exchange domain. For TXT: text data. For SRV: target. For PTR: domain name. For NS: nameserver. For CAA: value. For FWD: forwarder address.",
 				Required:    true,
 			},
 			"priority": schema.Int64Attribute{
@@ -119,6 +127,39 @@ func (r *RecordResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 			"caa_tag": schema.StringAttribute{
 				Description: "CAA record tag: issue, issuewild, iodef. Required for CAA records.",
 				Optional:    true,
+			},
+			"protocol": schema.StringAttribute{
+				Description: "FWD record DNS transport protocol: Udp, Tcp, Tls, Https, or Quic. Optional for FWD records; Technitium defaults to Udp.",
+				Optional:    true,
+			},
+			"forwarder_priority": schema.Int64Attribute{
+				Description: "FWD record priority. Lower values are queried first; same-priority forwarders are queried concurrently.",
+				Optional:    true,
+			},
+			"dnssec_validation": schema.BoolAttribute{
+				Description: "Whether DNSSEC validation must be done for this FWD record.",
+				Optional:    true,
+			},
+			"proxy_type": schema.StringAttribute{
+				Description: "Proxy type for FWD records: NoProxy, DefaultProxy, Http, or Socks5.",
+				Optional:    true,
+			},
+			"proxy_address": schema.StringAttribute{
+				Description: "Proxy server address for FWD records.",
+				Optional:    true,
+			},
+			"proxy_port": schema.Int64Attribute{
+				Description: "Proxy server port for FWD records.",
+				Optional:    true,
+			},
+			"proxy_username": schema.StringAttribute{
+				Description: "Proxy username for FWD records.",
+				Optional:    true,
+			},
+			"proxy_password": schema.StringAttribute{
+				Description: "Proxy password for FWD records.",
+				Optional:    true,
+				Sensitive:   true,
 			},
 			"overwrite": schema.BoolAttribute{
 				Description: "Replace existing record set for this type. Default: true.",
@@ -218,7 +259,12 @@ func (r *RecordResource) Read(ctx context.Context, req resource.ReadRequest, res
 	recordType := state.Type.ValueString()
 	for _, rec := range records {
 		if recordMatchesState(rec, &state) {
-			state.TTL = types.Int64Value(int64(rec.TTL))
+			if recordType == "FWD" && !state.TTL.IsNull() && !state.TTL.IsUnknown() {
+				// Technitium stores FWD records with TTL 0; preserve configured TTL
+				// to avoid perpetual diffs for an API-ignored field.
+			} else {
+				state.TTL = types.Int64Value(int64(rec.TTL))
+			}
 			state.Value = types.StringValue(client.RecordValueFromRData(recordType, rec.RData))
 			state.LastModified = types.StringValue(rec.LastModified)
 
@@ -232,7 +278,7 @@ func (r *RecordResource) Read(ctx context.Context, req resource.ReadRequest, res
 			if port, ok := rec.RData["port"]; ok {
 				state.Port = types.Int64Value(int64(toFloat64(port)))
 			}
-			if priority, ok := rec.RData["priority"]; ok {
+			if priority, ok := rec.RData["priority"]; ok && recordType != "FWD" {
 				state.Priority = types.Int64Value(int64(toFloat64(priority)))
 			}
 			// CAA fields
@@ -241,6 +287,22 @@ func (r *RecordResource) Read(ctx context.Context, req resource.ReadRequest, res
 			}
 			if tag, ok := rec.RData["tag"]; ok {
 				state.CAATag = types.StringValue(fmt.Sprintf("%v", tag))
+			}
+
+			// FWD fields
+			if protocol, ok := rec.RData["protocol"]; ok {
+				state.Protocol = types.StringValue(fmt.Sprintf("%v", protocol))
+			}
+			if priority, ok := rec.RData["priority"]; ok && recordType == "FWD" {
+				state.ForwarderPriority = types.Int64Value(int64(toFloat64(priority)))
+			}
+			if priority, ok := rec.RData["forwarderPriority"]; ok {
+				state.ForwarderPriority = types.Int64Value(int64(toFloat64(priority)))
+			}
+			if dnssecValidation, ok := rec.RData["dnssecValidation"]; ok {
+				if v, ok := dnssecValidation.(bool); ok {
+					state.DNSSECValidation = types.BoolValue(v)
+				}
 			}
 
 			found = true
@@ -375,6 +437,10 @@ func (r *RecordResource) ImportState(ctx context.Context, req resource.ImportSta
 		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("caa_flags"), caaFlags)...)
 		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("caa_tag"), caaTag)...)
 	}
+	if recordType == "FWD" {
+		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("protocol"), caaTag)...)
+		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("forwarder_priority"), priority)...)
+	}
 }
 
 // buildAddParams creates type-specific API parameters for record creation.
@@ -415,6 +481,19 @@ func (r *RecordResource) buildAddParams(model *RecordResourceModel) map[string]s
 		} else {
 			params["tag"] = "issue"
 		}
+	}
+
+	if recordType == "FWD" {
+		if !model.Protocol.IsNull() && model.Protocol.ValueString() != "" {
+			params["protocol"] = model.Protocol.ValueString()
+		}
+		if !model.ForwarderPriority.IsNull() {
+			params["forwarderPriority"] = fmt.Sprintf("%d", model.ForwarderPriority.ValueInt64())
+		}
+		if !model.DNSSECValidation.IsNull() {
+			params["dnssecValidation"] = fmt.Sprintf("%t", model.DNSSECValidation.ValueBool())
+		}
+		addOptionalFWDProxyParams(params, model)
 	}
 
 	return params
@@ -504,6 +583,27 @@ func (r *RecordResource) buildUpdateParams(state, plan *RecordResourceModel) map
 		if !plan.CAATag.IsNull() {
 			params["newTag"] = plan.CAATag.ValueString()
 		}
+	case "FWD":
+		params["forwarder"] = oldValue
+		if oldValue != newValue {
+			params["newForwarder"] = newValue
+		}
+		if !state.Protocol.IsNull() {
+			params["protocol"] = state.Protocol.ValueString()
+		}
+		if !plan.Protocol.IsNull() {
+			params["newProtocol"] = plan.Protocol.ValueString()
+		}
+		if !state.ForwarderPriority.IsNull() {
+			params["forwarderPriority"] = fmt.Sprintf("%d", state.ForwarderPriority.ValueInt64())
+		}
+		if !plan.ForwarderPriority.IsNull() {
+			params["newForwarderPriority"] = fmt.Sprintf("%d", plan.ForwarderPriority.ValueInt64())
+		}
+		if !plan.DNSSECValidation.IsNull() {
+			params["dnssecValidation"] = fmt.Sprintf("%t", plan.DNSSECValidation.ValueBool())
+		}
+		addOptionalFWDProxyParams(params, plan)
 	default:
 		params[valueParam] = newValue
 	}
@@ -544,6 +644,15 @@ func (r *RecordResource) buildDeleteParams(model *RecordResourceModel) map[strin
 		}
 	}
 
+	if recordType == "FWD" {
+		if !model.Protocol.IsNull() && model.Protocol.ValueString() != "" {
+			params["protocol"] = model.Protocol.ValueString()
+		}
+		if !model.ForwarderPriority.IsNull() {
+			params["forwarderPriority"] = fmt.Sprintf("%d", model.ForwarderPriority.ValueInt64())
+		}
+	}
+
 	return params
 }
 
@@ -558,5 +667,23 @@ func toFloat64(v interface{}) float64 {
 		return float64(n)
 	default:
 		return 0
+	}
+}
+
+func addOptionalFWDProxyParams(params map[string]string, model *RecordResourceModel) {
+	if !model.ProxyType.IsNull() && model.ProxyType.ValueString() != "" {
+		params["proxyType"] = model.ProxyType.ValueString()
+	}
+	if !model.ProxyAddress.IsNull() && model.ProxyAddress.ValueString() != "" {
+		params["proxyAddress"] = model.ProxyAddress.ValueString()
+	}
+	if !model.ProxyPort.IsNull() {
+		params["proxyPort"] = fmt.Sprintf("%d", model.ProxyPort.ValueInt64())
+	}
+	if !model.ProxyUsername.IsNull() && model.ProxyUsername.ValueString() != "" {
+		params["proxyUsername"] = model.ProxyUsername.ValueString()
+	}
+	if !model.ProxyPassword.IsNull() && model.ProxyPassword.ValueString() != "" {
+		params["proxyPassword"] = model.ProxyPassword.ValueString()
 	}
 }

--- a/internal/provider/record_resource.go
+++ b/internal/provider/record_resource.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
@@ -137,8 +138,28 @@ func (r *RecordResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 				Optional:    true,
 			},
 			"dnssec_validation": schema.BoolAttribute{
-				Description: "Whether DNSSEC validation must be done for this FWD record.",
-				Optional:    true,
+				Description: "Whether DNSSEC validation must be done for this FWD record. " +
+					"Changing this forces a new record, because the Technitium API cannot " +
+					"update it unambiguously when two FWD records differ only by this field.",
+				Optional: true,
+				PlanModifiers: []planmodifier.Bool{
+					// RequiresReplace, not in-place update. dnssecValidation is part of
+					// the FWD record's identity (see buildRecordID), but the update API
+					// treats it as a SETTABLE value, not an identifier: there is no
+					// newDnssecValidation parameter, so a record can only be located by
+					// forwarder/protocol/forwarderPriority. Measured against Technitium
+					// 15.4 with two records differing only by this field — an update
+					// rewrote one onto the other and the two COLLAPSED INTO ONE, with
+					// the API returning status "ok". Replacing routes the change through
+					// delete+create, which is well-defined for the ordinary single-record
+					// case. It does NOT rescue an existing colliding pair: delete ignores
+					// dnssecValidation when matching (see buildDeleteParams), so two FWD
+					// records differing only by this field cannot be addressed
+					// individually through the 15.4 API at all. The provider can keep
+					// them distinct in state — that is what buildRecordID fixes — but
+					// acting on one without disturbing the other is a server-side gap.
+					boolplanmodifier.RequiresReplace(),
+				},
 			},
 			"proxy_type": schema.StringAttribute{
 				Description: "Proxy type for FWD records: NoProxy, DefaultProxy, Http, or Socks5.",
@@ -608,8 +629,22 @@ func (r *RecordResource) buildUpdateParams(state, plan *RecordResourceModel) map
 		if !plan.ForwarderPriority.IsNull() {
 			params["newForwarderPriority"] = fmt.Sprintf("%d", plan.ForwarderPriority.ValueInt64())
 		}
-		if !plan.DNSSECValidation.IsNull() {
+		// Always send the current value, falling back to state when the config
+		// omits the attribute. Technitium treats a MISSING dnssecValidation on
+		// update as false rather than "leave alone": verified against 15.4, a
+		// TTL-only update silently flipped a dnssec=true record to false. Since
+		// the attribute is Optional and not Computed, a user who never writes it
+		// in HCL plans null on every apply, so without this fallback any
+		// unrelated update would quietly disable DNSSEC validation.
+		//
+		// dnssec_validation is RequiresReplace, so plan and state agree here for
+		// any update that actually reaches this code; the fallback exists for the
+		// null-plan case, not to reconcile a change.
+		switch {
+		case !plan.DNSSECValidation.IsNull():
 			params["dnssecValidation"] = fmt.Sprintf("%t", plan.DNSSECValidation.ValueBool())
+		case !state.DNSSECValidation.IsNull():
+			params["dnssecValidation"] = fmt.Sprintf("%t", state.DNSSECValidation.ValueBool())
 		}
 		addOptionalFWDProxyParams(params, plan)
 	default:
@@ -658,6 +693,25 @@ func (r *RecordResource) buildDeleteParams(model *RecordResourceModel) map[strin
 		}
 		if !model.ForwarderPriority.IsNull() {
 			params["forwarderPriority"] = fmt.Sprintf("%d", model.ForwarderPriority.ValueInt64())
+		}
+		// Sent for completeness and forward compatibility. Be clear about what
+		// this does NOT do: Technitium 15.4 IGNORES dnssecValidation when
+		// matching a record to delete. Measured with two FWD records differing
+		// only by this field, all four combinations of creation order and
+		// parameter value deleted the FIRST-CREATED record:
+		//
+		//   created true,false + delete dnssecValidation=true  -> True deleted
+		//   created true,false + delete dnssecValidation=false -> True deleted
+		//   created false,true + delete dnssecValidation=true  -> False deleted
+		//   created false,true + delete dnssecValidation=false -> False deleted
+		//
+		// So a colliding pair CANNOT be individually destroyed through this API,
+		// with or without this parameter. Sending it costs nothing, makes the
+		// request state the caller's intent, and starts working the day the
+		// server honours it. It is not a fix — see the schema note on
+		// dnssec_validation for the limitation and how the provider contains it.
+		if !model.DNSSECValidation.IsNull() {
+			params["dnssecValidation"] = fmt.Sprintf("%t", model.DNSSECValidation.ValueBool())
 		}
 	}
 

--- a/internal/provider/record_resource.go
+++ b/internal/provider/record_resource.go
@@ -148,14 +148,14 @@ func (r *RecordResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 					// treats it as a SETTABLE value, not an identifier: there is no
 					// newDnssecValidation parameter, so a record can only be located by
 					// forwarder/protocol/forwarderPriority. Measured against Technitium
-					// 15.4 with two records differing only by this field — an update
+					// 15.2 and 15.4 with two records differing only by this field — an update
 					// rewrote one onto the other and the two COLLAPSED INTO ONE, with
 					// the API returning status "ok". Replacing routes the change through
 					// delete+create, which is well-defined for the ordinary single-record
 					// case. It does NOT rescue an existing colliding pair: delete ignores
 					// dnssecValidation when matching (see buildDeleteParams), so two FWD
 					// records differing only by this field cannot be addressed
-					// individually through the 15.4 API at all. The provider can keep
+					// individually through the 15.2 and 15.4 APIs at all. The provider can keep
 					// them distinct in state — that is what buildRecordID fixes — but
 					// acting on one without disturbing the other is a server-side gap.
 					boolplanmodifier.RequiresReplace(),
@@ -646,7 +646,7 @@ func (r *RecordResource) buildUpdateParams(state, plan *RecordResourceModel) map
 		}
 		// Always send the current value, falling back to state when the config
 		// omits the attribute. Technitium treats a MISSING dnssecValidation on
-		// update as false rather than "leave alone": verified against 15.4, a
+		// update as false rather than "leave alone": verified against 15.2 and 15.4, a
 		// TTL-only update silently flipped a dnssec=true record to false. Since
 		// the attribute is Optional and not Computed, a user who never writes it
 		// in HCL plans null on every apply, so without this fallback any
@@ -710,7 +710,7 @@ func (r *RecordResource) buildDeleteParams(model *RecordResourceModel) map[strin
 			params["forwarderPriority"] = fmt.Sprintf("%d", model.ForwarderPriority.ValueInt64())
 		}
 		// Sent for completeness and forward compatibility. Be clear about what
-		// this does NOT do: Technitium 15.4 IGNORES dnssecValidation when
+		// this does NOT do: Technitium 15.2 and 15.4 IGNORE dnssecValidation when
 		// matching a record to delete. Measured with two FWD records differing
 		// only by this field, all four combinations of creation order and
 		// parameter value deleted the FIRST-CREATED record:

--- a/internal/provider/record_resource.go
+++ b/internal/provider/record_resource.go
@@ -320,9 +320,24 @@ func (r *RecordResource) Read(ctx context.Context, req resource.ReadRequest, res
 			if priority, ok := rec.RData["forwarderPriority"]; ok {
 				state.ForwarderPriority = types.Int64Value(int64(toFloat64(priority)))
 			}
-			if dnssecValidation, ok := rec.RData["dnssecValidation"]; ok {
-				if v, ok := dnssecValidation.(bool); ok {
-					state.DNSSECValidation = types.BoolValue(v)
+			// Only refresh dnssec_validation when it is already tracked. The
+			// attribute is Optional and NOT Computed, so a config that omits it
+			// plans as null; adopting the server's value here surfaces a permanent
+			// `false -> null` diff, and because the attribute is RequiresReplace
+			// that diff reads as "must be replaced" on every plan — a forced
+			// destroy/create of a record nobody touched.
+			//
+			// Caught by TestAccZoneResource_ForwarderConditional, whose upstreams
+			// deliberately omit the attribute (the common case for internal
+			// resolvers): the post-apply refresh plan was non-empty and both
+			// records were marked for replacement.
+			//
+			// Users who DO set the attribute still get real drift detection.
+			if !state.DNSSECValidation.IsNull() {
+				if dnssecValidation, ok := rec.RData["dnssecValidation"]; ok {
+					if v, ok := dnssecValidation.(bool); ok {
+						state.DNSSECValidation = types.BoolValue(v)
+					}
 				}
 			}
 

--- a/internal/provider/record_resource.go
+++ b/internal/provider/record_resource.go
@@ -406,7 +406,8 @@ func (r *RecordResource) ImportState(ctx context.Context, req resource.ImportSta
 				"(e.g., example.com::www.example.com::A::192.0.2.1). "+
 				"For MX: zone::name::MX::exchange:priority. "+
 				"For SRV: zone::name::SRV::target:priority:weight:port. "+
-				"For CAA: zone::name::CAA::value:flags:tag.")
+				"For CAA: zone::name::CAA::value:flags:tag. "+
+				"For FWD: zone::name::FWD::forwarder:protocol:priority[:dnssecValidation].")
 		return
 	}
 
@@ -417,32 +418,35 @@ func (r *RecordResource) ImportState(ctx context.Context, req resource.ImportSta
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("overwrite"), false)...)
 
 	// Parse value segment for type-specific fields
-	value, priority, weight, port, caaFlags, caaTag, parseErr := parseImportValueSegment(recordType, valueSegment)
+	fields, parseErr := parseImportValueSegment(recordType, valueSegment)
 	if parseErr != nil {
 		resp.Diagnostics.AddError("Invalid import value segment", parseErr.Error())
 		return
 	}
 
-	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("value"), value)...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("value"), fields.Value)...)
 
 	if recordType == "MX" {
-		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("priority"), priority)...)
+		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("priority"), fields.Priority)...)
 	}
 	if recordType == "SRV" {
-		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("priority"), priority)...)
-		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("weight"), weight)...)
-		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("port"), port)...)
+		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("priority"), fields.Priority)...)
+		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("weight"), fields.Weight)...)
+		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("port"), fields.Port)...)
 	}
 	if recordType == "CAA" {
-		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("caa_flags"), caaFlags)...)
-		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("caa_tag"), caaTag)...)
+		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("caa_flags"), fields.CAAFlags)...)
+		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("caa_tag"), fields.CAATag)...)
 	}
 	if recordType == "FWD" {
-		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("protocol"), caaTag)...)
-		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("forwarder_priority"), priority)...)
-		parts := strings.Split(valueSegment, ":")
-		if len(parts) >= 4 && (parts[len(parts)-1] == "true" || parts[len(parts)-1] == "false") {
-			resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("dnssec_validation"), parts[len(parts)-1] == "true")...)
+		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("protocol"), fields.Protocol)...)
+		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("forwarder_priority"), fields.Priority)...)
+		// Only set dnssec_validation when the import ID actually stated it. A
+		// legacy 3-field ID leaves this nil, and writing an explicit false there
+		// would fabricate state the user never supplied — which would then show
+		// up as spurious drift on the next plan.
+		if fields.DNSSECValidation != nil {
+			resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("dnssec_validation"), *fields.DNSSECValidation)...)
 		}
 	}
 }

--- a/internal/provider/record_resource_fwd_identity_test.go
+++ b/internal/provider/record_resource_fwd_identity_test.go
@@ -1,0 +1,86 @@
+// Copyright (c) 2026 Alex Ackerman
+// SPDX-License-Identifier: MPL-2.0
+
+package provider
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// fwdModel builds the minimum FWD state needed to exercise the param builders.
+func fwdModel(forwarder, protocol string, priority int64, dnssec *bool) *RecordResourceModel {
+	m := &RecordResourceModel{
+		Zone:              types.StringValue("fwd.example.com"),
+		Name:              types.StringValue("fwd.example.com"),
+		Type:              types.StringValue("FWD"),
+		Value:             types.StringValue(forwarder),
+		Protocol:          types.StringValue(protocol),
+		ForwarderPriority: types.Int64Value(priority),
+		DNSSECValidation:  types.BoolNull(),
+	}
+	if dnssec != nil {
+		m.DNSSECValidation = types.BoolValue(*dnssec)
+	}
+	return m
+}
+
+// TestBuildDeleteParams_FWD_DNSSECIsIdentifying is the regression test for the
+// destroy half of the FWD identity change.
+//
+// buildRecordID treats dnssecValidation as part of a FWD record's identity, so
+// the delete request states it too. This asserts the REQUEST SHAPE only.
+//
+// It deliberately does not claim the server disambiguates. Measured against live
+// Technitium 15.4, delete IGNORES dnssecValidation when matching: with two
+// records differing only by this field, all four combinations of creation order
+// and parameter value removed the FIRST-CREATED record. A colliding pair
+// therefore cannot be individually destroyed through the 15.4 API. Sending the
+// parameter makes the request express the caller's intent and starts working if
+// the server ever honours it; the provider contains the problem by marking
+// dnssec_validation RequiresReplace so it never attempts an in-place update,
+// which is the path that silently collapses two records into one.
+func TestBuildDeleteParams_FWD_DNSSECIsIdentifying(t *testing.T) {
+	r := &RecordResource{}
+	tr, fa := true, false
+
+	paramsTrue := r.buildDeleteParams(fwdModel("1.1.1.1", "Udp", 1, &tr))
+	paramsFalse := r.buildDeleteParams(fwdModel("1.1.1.1", "Udp", 1, &fa))
+
+	if got := paramsTrue["dnssecValidation"]; got != "true" {
+		t.Errorf("dnssecValidation = %q, want \"true\"", got)
+	}
+	if got := paramsFalse["dnssecValidation"]; got != "false" {
+		t.Errorf("dnssecValidation = %q, want \"false\"", got)
+	}
+
+	// The point of the test: two records identical in every other respect must
+	// produce DIFFERENT delete requests, or the API cannot tell them apart.
+	if paramsTrue["dnssecValidation"] == paramsFalse["dnssecValidation"] {
+		t.Fatal("delete params for the true/false siblings are identical — " +
+			"the API would delete whichever was created first")
+	}
+	for _, k := range []string{"forwarder", "protocol", "forwarderPriority"} {
+		if paramsTrue[k] != paramsFalse[k] {
+			t.Errorf("%s differs between siblings (%q vs %q); the collision case "+
+				"requires these to match so dnssecValidation is the only discriminator",
+				k, paramsTrue[k], paramsFalse[k])
+		}
+	}
+}
+
+// TestBuildDeleteParams_FWD_DNSSECOmittedWhenNull covers the legacy path: a
+// record imported with a 3-field ID has dnssec_validation null, and the delete
+// request must then omit the parameter rather than assert a value the user
+// never supplied.
+func TestBuildDeleteParams_FWD_DNSSECOmittedWhenNull(t *testing.T) {
+	r := &RecordResource{}
+	params := r.buildDeleteParams(fwdModel("1.1.1.1", "Udp", 1, nil))
+	if v, present := params["dnssecValidation"]; present {
+		t.Errorf("dnssecValidation = %q, want the key to be absent when state is null", v)
+	}
+	if params["forwarder"] != "1.1.1.1" || params["protocol"] != "Udp" || params["forwarderPriority"] != "1" {
+		t.Errorf("legacy identity params malformed: %v", params)
+	}
+}

--- a/internal/provider/record_resource_fwd_identity_test.go
+++ b/internal/provider/record_resource_fwd_identity_test.go
@@ -33,10 +33,10 @@ func fwdModel(forwarder, protocol string, priority int64, dnssec *bool) *RecordR
 // the delete request states it too. This asserts the REQUEST SHAPE only.
 //
 // It deliberately does not claim the server disambiguates. Measured against live
-// Technitium 15.4, delete IGNORES dnssecValidation when matching: with two
+// Technitium 15.2 and 15.4, delete IGNORES dnssecValidation when matching: with two
 // records differing only by this field, all four combinations of creation order
 // and parameter value removed the FIRST-CREATED record. A colliding pair
-// therefore cannot be individually destroyed through the 15.4 API. Sending the
+// therefore cannot be individually destroyed through the 15.2 and 15.4 APIs. Sending the
 // parameter makes the request express the caller's intent and starts working if
 // the server ever honours it; the provider contains the problem by marking
 // dnssec_validation RequiresReplace so it never attempts an in-place update,

--- a/internal/provider/record_resource_import_test.go
+++ b/internal/provider/record_resource_import_test.go
@@ -1,0 +1,126 @@
+package provider
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+// newImportState builds an empty state backed by the record resource's real
+// schema, so ImportState can be exercised without a live provider server.
+func newImportState(t *testing.T, ctx context.Context) tfsdk.State {
+	t.Helper()
+	r := &RecordResource{}
+	schemaResp := resource.SchemaResponse{}
+	r.Schema(ctx, resource.SchemaRequest{}, &schemaResp)
+	if schemaResp.Diagnostics.HasError() {
+		t.Fatalf("schema error: %v", schemaResp.Diagnostics)
+	}
+	return tfsdk.State{
+		Schema: schemaResp.Schema,
+		Raw:    tftypes.NewValue(schemaResp.Schema.Type().TerraformType(ctx), nil),
+	}
+}
+
+// TestImportState_FWD covers the regression that made this worth testing at the
+// state level rather than only at the parser: ImportState used to read the
+// parser's shared string slot under the name caaTag and write it straight into
+// the protocol attribute. It happened to work because FWD and CAA shared that
+// slot, and nothing asserted the resulting state.
+func TestImportState_FWD(t *testing.T) {
+	ctx := context.Background()
+	r := &RecordResource{}
+
+	tests := []struct {
+		name         string
+		importID     string
+		wantValue    string
+		wantProtocol string
+		wantPriority int64
+		// wantDNSSEC nil means the attribute must be left null, which is what a
+		// legacy 3-field import ID has to produce.
+		wantDNSSEC *bool
+	}{
+		{
+			name:         "4-field with dnssec true",
+			importID:     ".::.::FWD::1.1.1.1:Udp:2:true",
+			wantValue:    "1.1.1.1",
+			wantProtocol: "Udp",
+			wantPriority: 2,
+			wantDNSSEC:   boolPtrForTest(true),
+		},
+		{
+			name:         "4-field with dnssec false",
+			importID:     ".::.::FWD::1.1.1.1:Udp:2:false",
+			wantValue:    "1.1.1.1",
+			wantProtocol: "Udp",
+			wantPriority: 2,
+			wantDNSSEC:   boolPtrForTest(false),
+		},
+		{
+			name:         "legacy 3-field leaves dnssec_validation null",
+			importID:     ".::.::FWD::1.1.1.1:Udp:2",
+			wantValue:    "1.1.1.1",
+			wantProtocol: "Udp",
+			wantPriority: 2,
+			wantDNSSEC:   nil,
+		},
+		{
+			name:         "DoH forwarder containing colons",
+			importID:     ".::.::FWD::https://cloudflare-dns.com/dns-query:Https:1:true",
+			wantValue:    "https://cloudflare-dns.com/dns-query",
+			wantProtocol: "Https",
+			wantPriority: 1,
+			wantDNSSEC:   boolPtrForTest(true),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			resp := resource.ImportStateResponse{State: newImportState(t, ctx)}
+			r.ImportState(ctx, resource.ImportStateRequest{ID: tc.importID}, &resp)
+			if resp.Diagnostics.HasError() {
+				t.Fatalf("ImportState returned errors: %v", resp.Diagnostics)
+			}
+
+			var got RecordResourceModel
+			if diags := resp.State.Get(ctx, &got); diags.HasError() {
+				t.Fatalf("reading state: %v", diags)
+			}
+
+			if got.Type.ValueString() != "FWD" {
+				t.Errorf("type = %q, want FWD", got.Type.ValueString())
+			}
+			if got.Value.ValueString() != tc.wantValue {
+				t.Errorf("value = %q, want %q", got.Value.ValueString(), tc.wantValue)
+			}
+			if got.Protocol.ValueString() != tc.wantProtocol {
+				t.Errorf("protocol = %q, want %q", got.Protocol.ValueString(), tc.wantProtocol)
+			}
+			if got.ForwarderPriority.ValueInt64() != tc.wantPriority {
+				t.Errorf("forwarder_priority = %d, want %d", got.ForwarderPriority.ValueInt64(), tc.wantPriority)
+			}
+
+			if tc.wantDNSSEC == nil {
+				if !got.DNSSECValidation.IsNull() {
+					t.Errorf("dnssec_validation = %v, want null — a legacy import ID must not "+
+						"fabricate a value, or the next plan shows spurious drift",
+						got.DNSSECValidation.ValueBool())
+				}
+				return
+			}
+			if got.DNSSECValidation.IsNull() {
+				t.Fatalf("dnssec_validation is null, want %v", *tc.wantDNSSEC)
+			}
+			if got.DNSSECValidation.ValueBool() != *tc.wantDNSSEC {
+				t.Errorf("dnssec_validation = %v, want %v",
+					got.DNSSECValidation.ValueBool(), *tc.wantDNSSEC)
+			}
+		})
+	}
+}
+
+func boolPtrForTest(b bool) *bool { return &b }

--- a/internal/provider/server_settings_data_source.go
+++ b/internal/provider/server_settings_data_source.go
@@ -24,17 +24,17 @@ type ServerSettingsDataSource struct {
 }
 
 type ServerSettingsDataSourceModel struct {
-	ID                          types.String `tfsdk:"id"`
-	Version                     types.String `tfsdk:"version"`
-	Uptime                      types.String `tfsdk:"uptime"`
-	DnssecValidation            types.Bool   `tfsdk:"dnssec_validation"`
-	Recursion                   types.String `tfsdk:"recursion"`
-	QnameMinimization           types.Bool   `tfsdk:"qname_minimization"`
-	RandomizeName               types.Bool   `tfsdk:"randomize_name"`
-	LogQueries                  types.Bool   `tfsdk:"log_queries"`
-	LoggingType                 types.String `tfsdk:"logging_type"`
-	MaxLogFileDays              types.Int64  `tfsdk:"max_log_file_days"`
-	EnableBlocking              types.Bool   `tfsdk:"enable_blocking"`
+	ID                           types.String `tfsdk:"id"`
+	Version                      types.String `tfsdk:"version"`
+	Uptime                       types.String `tfsdk:"uptime"`
+	DnssecValidation             types.Bool   `tfsdk:"dnssec_validation"`
+	Recursion                    types.String `tfsdk:"recursion"`
+	QnameMinimization            types.Bool   `tfsdk:"qname_minimization"`
+	RandomizeName                types.Bool   `tfsdk:"randomize_name"`
+	LogQueries                   types.Bool   `tfsdk:"log_queries"`
+	LoggingType                  types.String `tfsdk:"logging_type"`
+	MaxLogFileDays               types.Int64  `tfsdk:"max_log_file_days"`
+	EnableBlocking               types.Bool   `tfsdk:"enable_blocking"`
 	AllowTxtBlockingReport       types.Bool   `tfsdk:"allow_txt_blocking_report"`
 	BlockingBypassList           types.List   `tfsdk:"blocking_bypass_list"`
 	BlockingType                 types.String `tfsdk:"blocking_type"`
@@ -42,13 +42,13 @@ type ServerSettingsDataSourceModel struct {
 	CustomBlockingAddresses      types.List   `tfsdk:"custom_blocking_addresses"`
 	BlockListUrls                types.List   `tfsdk:"block_list_urls"`
 	BlockListUpdateIntervalHours types.Int64  `tfsdk:"block_list_update_interval_hours"`
-	ServeStale                  types.Bool   `tfsdk:"serve_stale"`
-	ForwarderProtocol           types.String `tfsdk:"forwarder_protocol"`
-	EnableDnsOverTls            types.Bool   `tfsdk:"enable_dns_over_tls"`
-	EnableDnsOverHttps          types.Bool   `tfsdk:"enable_dns_over_https"`
-	UdpPayloadSize              types.Int64  `tfsdk:"udp_payload_size"`
-	CacheMinimumRecordTtl       types.Int64  `tfsdk:"cache_minimum_record_ttl"`
-	CacheMaximumRecordTtl       types.Int64  `tfsdk:"cache_maximum_record_ttl"`
+	ServeStale                   types.Bool   `tfsdk:"serve_stale"`
+	ForwarderProtocol            types.String `tfsdk:"forwarder_protocol"`
+	EnableDnsOverTls             types.Bool   `tfsdk:"enable_dns_over_tls"`
+	EnableDnsOverHttps           types.Bool   `tfsdk:"enable_dns_over_https"`
+	UdpPayloadSize               types.Int64  `tfsdk:"udp_payload_size"`
+	CacheMinimumRecordTtl        types.Int64  `tfsdk:"cache_minimum_record_ttl"`
+	CacheMaximumRecordTtl        types.Int64  `tfsdk:"cache_maximum_record_ttl"`
 }
 
 func (d *ServerSettingsDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
@@ -59,16 +59,16 @@ func (d *ServerSettingsDataSource) Schema(_ context.Context, _ datasource.Schema
 	resp.Schema = schema.Schema{
 		Description: "Reads current Technitium DNS Server settings for compliance auditing.",
 		Attributes: map[string]schema.Attribute{
-			"id":                     schema.StringAttribute{Computed: true, Description: "Fixed identifier."},
-			"version":                schema.StringAttribute{Computed: true, Description: "Server version."},
-			"uptime":                 schema.StringAttribute{Computed: true, Description: "Server uptime timestamp."},
-			"dnssec_validation":      schema.BoolAttribute{Computed: true, Description: "DNSSEC validation enabled."},
-			"recursion":              schema.StringAttribute{Computed: true, Description: "Recursion policy."},
-			"qname_minimization":     schema.BoolAttribute{Computed: true, Description: "QNAME minimization enabled."},
-			"randomize_name":         schema.BoolAttribute{Computed: true, Description: "Query name randomization enabled."},
-			"log_queries":            schema.BoolAttribute{Computed: true, Description: "Query logging enabled."},
-			"logging_type":           schema.StringAttribute{Computed: true, Description: "Logging output type."},
-			"max_log_file_days":      schema.Int64Attribute{Computed: true, Description: "Max log retention days."},
+			"id":                               schema.StringAttribute{Computed: true, Description: "Fixed identifier."},
+			"version":                          schema.StringAttribute{Computed: true, Description: "Server version."},
+			"uptime":                           schema.StringAttribute{Computed: true, Description: "Server uptime timestamp."},
+			"dnssec_validation":                schema.BoolAttribute{Computed: true, Description: "DNSSEC validation enabled."},
+			"recursion":                        schema.StringAttribute{Computed: true, Description: "Recursion policy."},
+			"qname_minimization":               schema.BoolAttribute{Computed: true, Description: "QNAME minimization enabled."},
+			"randomize_name":                   schema.BoolAttribute{Computed: true, Description: "Query name randomization enabled."},
+			"log_queries":                      schema.BoolAttribute{Computed: true, Description: "Query logging enabled."},
+			"logging_type":                     schema.StringAttribute{Computed: true, Description: "Logging output type."},
+			"max_log_file_days":                schema.Int64Attribute{Computed: true, Description: "Max log retention days."},
 			"enable_blocking":                  schema.BoolAttribute{Computed: true, Description: "DNS blocking enabled."},
 			"allow_txt_blocking_report":        schema.BoolAttribute{Computed: true, Description: "TXT blocking report queries allowed."},
 			"blocking_bypass_list":             schema.ListAttribute{Computed: true, ElementType: types.StringType, Description: "Domains/networks that bypass blocking."},
@@ -77,13 +77,13 @@ func (d *ServerSettingsDataSource) Schema(_ context.Context, _ datasource.Schema
 			"custom_blocking_addresses":        schema.ListAttribute{Computed: true, ElementType: types.StringType, Description: "Custom IPs returned for blocked queries."},
 			"block_list_urls":                  schema.ListAttribute{Computed: true, ElementType: types.StringType, Description: "Block list feed URLs."},
 			"block_list_update_interval_hours": schema.Int64Attribute{Computed: true, Description: "Hours between block list updates."},
-			"serve_stale":            schema.BoolAttribute{Computed: true, Description: "Serve stale records enabled."},
-			"forwarder_protocol":     schema.StringAttribute{Computed: true, Description: "Forwarder protocol."},
-			"enable_dns_over_tls":    schema.BoolAttribute{Computed: true, Description: "DNS-over-TLS enabled."},
-			"enable_dns_over_https":  schema.BoolAttribute{Computed: true, Description: "DNS-over-HTTPS enabled."},
-			"udp_payload_size":       schema.Int64Attribute{Computed: true, Description: "EDNS UDP payload size."},
-			"cache_minimum_record_ttl": schema.Int64Attribute{Computed: true, Description: "Minimum cache TTL."},
-			"cache_maximum_record_ttl": schema.Int64Attribute{Computed: true, Description: "Maximum cache TTL."},
+			"serve_stale":                      schema.BoolAttribute{Computed: true, Description: "Serve stale records enabled."},
+			"forwarder_protocol":               schema.StringAttribute{Computed: true, Description: "Forwarder protocol."},
+			"enable_dns_over_tls":              schema.BoolAttribute{Computed: true, Description: "DNS-over-TLS enabled."},
+			"enable_dns_over_https":            schema.BoolAttribute{Computed: true, Description: "DNS-over-HTTPS enabled."},
+			"udp_payload_size":                 schema.Int64Attribute{Computed: true, Description: "EDNS UDP payload size."},
+			"cache_minimum_record_ttl":         schema.Int64Attribute{Computed: true, Description: "Minimum cache TTL."},
+			"cache_maximum_record_ttl":         schema.Int64Attribute{Computed: true, Description: "Maximum cache TTL."},
 		},
 	}
 }

--- a/internal/provider/server_settings_resource.go
+++ b/internal/provider/server_settings_resource.go
@@ -40,16 +40,16 @@ type ServerSettingsResource struct {
 }
 
 type ServerSettingsResourceModel struct {
-	ID                          types.String `tfsdk:"id"`
-	DnssecValidation            types.Bool   `tfsdk:"dnssec_validation"`
-	Recursion                   types.String `tfsdk:"recursion"`
-	RecursionNetworkACL         types.List   `tfsdk:"recursion_network_acl"`
-	QnameMinimization           types.Bool   `tfsdk:"qname_minimization"`
-	RandomizeName               types.Bool   `tfsdk:"randomize_name"`
-	LogQueries                  types.Bool   `tfsdk:"log_queries"`
-	LoggingType                 types.String `tfsdk:"logging_type"`
-	MaxLogFileDays              types.Int64  `tfsdk:"max_log_file_days"`
-	EnableBlocking              types.Bool   `tfsdk:"enable_blocking"`
+	ID                           types.String `tfsdk:"id"`
+	DnssecValidation             types.Bool   `tfsdk:"dnssec_validation"`
+	Recursion                    types.String `tfsdk:"recursion"`
+	RecursionNetworkACL          types.List   `tfsdk:"recursion_network_acl"`
+	QnameMinimization            types.Bool   `tfsdk:"qname_minimization"`
+	RandomizeName                types.Bool   `tfsdk:"randomize_name"`
+	LogQueries                   types.Bool   `tfsdk:"log_queries"`
+	LoggingType                  types.String `tfsdk:"logging_type"`
+	MaxLogFileDays               types.Int64  `tfsdk:"max_log_file_days"`
+	EnableBlocking               types.Bool   `tfsdk:"enable_blocking"`
 	AllowTxtBlockingReport       types.Bool   `tfsdk:"allow_txt_blocking_report"`
 	BlockingBypassList           types.List   `tfsdk:"blocking_bypass_list"`
 	BlockingType                 types.String `tfsdk:"blocking_type"`
@@ -57,16 +57,16 @@ type ServerSettingsResourceModel struct {
 	CustomBlockingAddresses      types.List   `tfsdk:"custom_blocking_addresses"`
 	BlockListUrls                types.List   `tfsdk:"block_list_urls"`
 	BlockListUpdateIntervalHours types.Int64  `tfsdk:"block_list_update_interval_hours"`
-	ServeStale                  types.Bool   `tfsdk:"serve_stale"`
-	Forwarders                  types.List   `tfsdk:"forwarders"`
-	ForwarderProtocol           types.String `tfsdk:"forwarder_protocol"`
-	EnableDnsOverTls            types.Bool   `tfsdk:"enable_dns_over_tls"`
-	EnableDnsOverHttps          types.Bool   `tfsdk:"enable_dns_over_https"`
-	ZoneTransferAllowedNetworks types.List   `tfsdk:"zone_transfer_allowed_networks"`
-	NotifyAllowedNetworks       types.List   `tfsdk:"notify_allowed_networks"`
-	UdpPayloadSize              types.Int64  `tfsdk:"udp_payload_size"`
-	CacheMinimumRecordTtl       types.Int64  `tfsdk:"cache_minimum_record_ttl"`
-	CacheMaximumRecordTtl       types.Int64  `tfsdk:"cache_maximum_record_ttl"`
+	ServeStale                   types.Bool   `tfsdk:"serve_stale"`
+	Forwarders                   types.List   `tfsdk:"forwarders"`
+	ForwarderProtocol            types.String `tfsdk:"forwarder_protocol"`
+	EnableDnsOverTls             types.Bool   `tfsdk:"enable_dns_over_tls"`
+	EnableDnsOverHttps           types.Bool   `tfsdk:"enable_dns_over_https"`
+	ZoneTransferAllowedNetworks  types.List   `tfsdk:"zone_transfer_allowed_networks"`
+	NotifyAllowedNetworks        types.List   `tfsdk:"notify_allowed_networks"`
+	UdpPayloadSize               types.Int64  `tfsdk:"udp_payload_size"`
+	CacheMinimumRecordTtl        types.Int64  `tfsdk:"cache_minimum_record_ttl"`
+	CacheMaximumRecordTtl        types.Int64  `tfsdk:"cache_maximum_record_ttl"`
 	// Computed
 	Version types.String `tfsdk:"version"`
 	Uptime  types.String `tfsdk:"uptime"`

--- a/internal/provider/zone_data_source.go
+++ b/internal/provider/zone_data_source.go
@@ -27,16 +27,16 @@ type ZoneDataSource struct {
 
 // ZoneDataSourceModel describes the data source data model.
 type ZoneDataSourceModel struct {
-	ID                  types.String `tfsdk:"id"`
-	Name                types.String `tfsdk:"name"`
-	Type                types.String `tfsdk:"type"`
-	Disabled            types.Bool   `tfsdk:"disabled"`
-	DNSSECStatus        types.String `tfsdk:"dnssec_status"`
-	SOASerial           types.Int64  `tfsdk:"soa_serial"`
-	ZoneTransfer        types.String `tfsdk:"zone_transfer"`
-	ZoneTransferACL     types.List   `tfsdk:"zone_transfer_acl"`
-	Notify              types.String `tfsdk:"notify"`
-	NotifyNameServers   types.List   `tfsdk:"notify_name_servers"`
+	ID                types.String `tfsdk:"id"`
+	Name              types.String `tfsdk:"name"`
+	Type              types.String `tfsdk:"type"`
+	Disabled          types.Bool   `tfsdk:"disabled"`
+	DNSSECStatus      types.String `tfsdk:"dnssec_status"`
+	SOASerial         types.Int64  `tfsdk:"soa_serial"`
+	ZoneTransfer      types.String `tfsdk:"zone_transfer"`
+	ZoneTransferACL   types.List   `tfsdk:"zone_transfer_acl"`
+	Notify            types.String `tfsdk:"notify"`
+	NotifyNameServers types.List   `tfsdk:"notify_name_servers"`
 }
 
 func (d *ZoneDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {

--- a/internal/provider/zone_resource.go
+++ b/internal/provider/zone_resource.go
@@ -479,9 +479,18 @@ func (r *ZoneResource) readZoneState(ctx context.Context, model *ZoneResourceMod
 		return fmt.Errorf("reading zone options: %w", err)
 	}
 
-	model.ID = types.StringValue(zone.Name)
-	model.Name = types.StringValue(zone.Name)
-	model.Type = types.StringValue(zone.Type)
+	zoneName := zone.Name
+	if zoneName == "" {
+		zoneName = model.Name.ValueString()
+	}
+	zoneType := zone.Type
+	if zoneType == "" {
+		zoneType = model.Type.ValueString()
+	}
+
+	model.ID = types.StringValue(zoneName)
+	model.Name = types.StringValue(zoneName)
+	model.Type = types.StringValue(zoneType)
 	model.DNSSECStatus = types.StringValue(zone.DNSSECStatus)
 
 	if zone.Disabled {
@@ -530,10 +539,13 @@ func (r *ZoneResource) readZoneState(ctx context.Context, model *ZoneResourceMod
 		return fmt.Errorf("listing zones for SOA serial: %w", err)
 	}
 	for _, z := range zones {
-		if strings.EqualFold(z.Name, zone.Name) {
+		if strings.EqualFold(z.Name, zoneName) || (zoneName == "." && z.Name == "") {
 			model.SOASerial = types.Int64Value(int64(z.SOASerial))
 			break
 		}
+	}
+	if model.SOASerial.IsUnknown() || model.SOASerial.IsNull() {
+		model.SOASerial = types.Int64Value(0)
 	}
 
 	// Read DNSSEC state

--- a/internal/provider/zone_resource.go
+++ b/internal/provider/zone_resource.go
@@ -548,6 +548,9 @@ func (r *ZoneResource) readZoneState(ctx context.Context, model *ZoneResourceMod
 		model.SOASerial = types.Int64Value(0)
 	}
 
+	// Set SOASerialDateScheme to match provider default (true)
+	model.SOASerialDateScheme = types.BoolValue(true)
+
 	// Read DNSSEC state
 	if zone.DNSSECStatus != "Unsigned" && zone.DNSSECStatus != "" {
 		props, err := r.client.ZoneDNSSECPropertiesGet(ctx, model.Name.ValueString())

--- a/internal/provider/zone_resource_forwarder_test.go
+++ b/internal/provider/zone_resource_forwarder_test.go
@@ -105,3 +105,123 @@ resource "technitium_record" "fwd" {
 }
 `, zone, zone, forwarder, protocol, priority, dnssec)
 }
+
+// TestAccZoneResource_ForwarderSafeDualPattern applies the exact shape shipped in
+// examples/resources/technitium_record/fwd-record.tf and documented under "DNSSEC
+// validation on forwarders": two forwarders on the same zone, each with
+// dnssec_validation set explicitly and each given a DISTINCT forwarder_priority.
+//
+// This exists because the documented workaround is only worth documenting if it
+// actually works. Priority is part of the identity the Technitium API matches on,
+// so records that differ by it stay individually addressable — unlike a pair that
+// differs only by dnssec_validation, which the API cannot tell apart. The final
+// destroy is the part that matters: it must remove both records rather than
+// deleting one twice.
+func TestAccZoneResource_ForwarderSafeDualPattern(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccZoneForwarderSafeDualConfig("acc-fwd-safe.example.com"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("technitium_record.validating", "forwarder_priority", "1"),
+					resource.TestCheckResourceAttr("technitium_record.validating", "dnssec_validation", "true"),
+					resource.TestCheckResourceAttr("technitium_record.non_validating", "forwarder_priority", "2"),
+					resource.TestCheckResourceAttr("technitium_record.non_validating", "dnssec_validation", "false"),
+					// Same forwarder and protocol: priority is the only discriminator,
+					// which is exactly what the documentation tells users to rely on.
+					resource.TestCheckResourceAttr("technitium_record.validating", "value", "1.1.1.1"),
+					resource.TestCheckResourceAttr("technitium_record.non_validating", "value", "1.1.1.1"),
+					resource.TestCheckResourceAttr("technitium_record.validating", "protocol", "Udp"),
+					resource.TestCheckResourceAttr("technitium_record.non_validating", "protocol", "Udp"),
+				),
+			},
+		},
+	})
+}
+
+func testAccZoneForwarderSafeDualConfig(zone string) string {
+	return testAccProviderHCL() + fmt.Sprintf(`
+resource "technitium_zone" "safe_fwd" {
+  name = %q
+  type = "Forwarder"
+}
+
+resource "technitium_record" "validating" {
+  zone               = technitium_zone.safe_fwd.name
+  name               = technitium_zone.safe_fwd.name
+  type               = "FWD"
+  value              = "1.1.1.1"
+  protocol           = "Udp"
+  forwarder_priority = 1
+  dnssec_validation  = true
+  overwrite          = false
+}
+
+resource "technitium_record" "non_validating" {
+  zone               = technitium_zone.safe_fwd.name
+  name               = technitium_zone.safe_fwd.name
+  type               = "FWD"
+  value              = "1.1.1.1"
+  protocol           = "Udp"
+  forwarder_priority = 2
+  dnssec_validation  = false
+  overwrite          = false
+}
+`, zone)
+}
+
+// TestAccZoneResource_ForwarderConditional applies the conditional-forwarding
+// example: a NAMED Forwarder zone (not the root ".") with a redundant pair of
+// upstreams distinguished by value and priority.
+//
+// The named-zone case is the one issue #75 was actually reported against —
+// "remote.my.company.net", not "." — so it is worth covering directly rather
+// than assuming the apex behaves the same.
+func TestAccZoneResource_ForwarderConditional(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccZoneForwarderConditionalConfig("acc-corp.example.net"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("technitium_zone.corp", "type", "Forwarder"),
+					resource.TestCheckResourceAttr("technitium_zone.corp", "name", "acc-corp.example.net"),
+					resource.TestCheckResourceAttr("technitium_record.primary", "value", "10.10.0.53"),
+					resource.TestCheckResourceAttr("technitium_record.primary", "forwarder_priority", "1"),
+					resource.TestCheckResourceAttr("technitium_record.secondary", "value", "10.20.0.53"),
+					resource.TestCheckResourceAttr("technitium_record.secondary", "forwarder_priority", "2"),
+				),
+			},
+		},
+	})
+}
+
+func testAccZoneForwarderConditionalConfig(zone string) string {
+	return testAccProviderHCL() + fmt.Sprintf(`
+resource "technitium_zone" "corp" {
+  name = %q
+  type = "Forwarder"
+}
+
+resource "technitium_record" "primary" {
+  zone               = technitium_zone.corp.name
+  name               = technitium_zone.corp.name
+  type               = "FWD"
+  value              = "10.10.0.53"
+  protocol           = "Udp"
+  forwarder_priority = 1
+  overwrite          = false
+}
+
+resource "technitium_record" "secondary" {
+  zone               = technitium_zone.corp.name
+  name               = technitium_zone.corp.name
+  type               = "FWD"
+  value              = "10.20.0.53"
+  protocol           = "Udp"
+  forwarder_priority = 2
+  overwrite          = false
+}
+`, zone)
+}

--- a/internal/provider/zone_resource_forwarder_test.go
+++ b/internal/provider/zone_resource_forwarder_test.go
@@ -22,7 +22,7 @@ import (
 // That behaviour was previously covered only by a httptest mock
 // (TestZoneCreate_ForwarderCreatesEmptyZone), which asserts the query string the
 // client *sends* and therefore cannot detect a server that rejects it. Verified
-// against live Technitium 15.4:
+// against live Technitium 15.2 and 15.4:
 //
 //	POST /api/zones/create?zone=X&type=Forwarder
 //	  -> {"status":"error","errorMessage":"Parameter 'forwarder' missing."}

--- a/internal/provider/zone_resource_forwarder_test.go
+++ b/internal/provider/zone_resource_forwarder_test.go
@@ -1,0 +1,107 @@
+// Copyright (c) 2026 Alex Ackerman
+// SPDX-License-Identifier: MPL-2.0
+
+package provider
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+// TestAccZoneResource_Forwarder is the end-to-end regression test for issue #75
+// ("Forwarder zone - cannot be created").
+//
+// Technitium refuses to create a Forwarder zone unless the request either
+// supplies an initial `forwarder` parameter or opts out with
+// `initializeForwarder=false`. The provider does the latter so that FWD records
+// can be managed declaratively as separate technitium_record resources instead
+// of being baked into zone creation.
+//
+// That behaviour was previously covered only by a httptest mock
+// (TestZoneCreate_ForwarderCreatesEmptyZone), which asserts the query string the
+// client *sends* and therefore cannot detect a server that rejects it. Verified
+// against live Technitium 15.4:
+//
+//	POST /api/zones/create?zone=X&type=Forwarder
+//	  -> {"status":"error","errorMessage":"Parameter 'forwarder' missing."}
+//	POST /api/zones/create?zone=X&type=Forwarder&initializeForwarder=false
+//	  -> {"status":"ok"}
+//
+// The reporter used a NAMED zone; the mock covers the root zone ".". Both are
+// exercised here because "works at the apex" would not have implied the other.
+func TestAccZoneResource_Forwarder(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccZoneResourceForwarderConfig("acc-forwarder.example.com"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("technitium_zone.forwarder", "name", "acc-forwarder.example.com"),
+					resource.TestCheckResourceAttr("technitium_zone.forwarder", "type", "Forwarder"),
+					resource.TestCheckResourceAttr("technitium_zone.forwarder", "status", "enabled"),
+				),
+			},
+			{
+				ResourceName:            "technitium_zone.forwarder",
+				ImportState:             true,
+				ImportStateId:           "acc-forwarder.example.com",
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"soa_serial_date_scheme", "dnssec"},
+			},
+		},
+	})
+}
+
+// TestAccZoneResource_ForwarderWithRecord covers the workflow the provider docs
+// actually recommend for issue #75: create the Forwarder zone empty, then attach
+// FWD records as independent resources. This is the combination that broke —
+// zone creation failing meant the documented example could never be applied.
+func TestAccZoneResource_ForwarderWithRecord(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccZoneForwarderWithRecordConfig("acc-fwd-rec.example.com", "1.1.1.1", "Udp", 1, true),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("technitium_zone.fwd_zone", "type", "Forwarder"),
+					resource.TestCheckResourceAttr("technitium_record.fwd", "type", "FWD"),
+					resource.TestCheckResourceAttr("technitium_record.fwd", "value", "1.1.1.1"),
+					resource.TestCheckResourceAttr("technitium_record.fwd", "protocol", "Udp"),
+					resource.TestCheckResourceAttr("technitium_record.fwd", "forwarder_priority", "1"),
+					resource.TestCheckResourceAttr("technitium_record.fwd", "dnssec_validation", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccZoneResourceForwarderConfig(name string) string {
+	return testAccProviderHCL() + fmt.Sprintf(`
+resource "technitium_zone" "forwarder" {
+  name = %q
+  type = "Forwarder"
+}
+`, name)
+}
+
+func testAccZoneForwarderWithRecordConfig(zone, forwarder, protocol string, priority int, dnssec bool) string {
+	return testAccProviderHCL() + fmt.Sprintf(`
+resource "technitium_zone" "fwd_zone" {
+  name = %q
+  type = "Forwarder"
+}
+
+resource "technitium_record" "fwd" {
+  zone               = technitium_zone.fwd_zone.name
+  name               = %q
+  type               = "FWD"
+  value              = %q
+  protocol           = %q
+  forwarder_priority = %d
+  dnssec_validation  = %t
+  overwrite          = false
+}
+`, zone, zone, forwarder, protocol, priority, dnssec)
+}

--- a/templates/resources/record.md.tmpl
+++ b/templates/resources/record.md.tmpl
@@ -3,13 +3,13 @@ subcategory: ""
 page_title: "technitium_record Resource - Technitium DNS Server"
 description: |-
   Manages a DNS record in a Technitium DNS zone. Supports A, AAAA, CNAME, MX, TXT, SRV,
-  PTR, NS, and CAA record types. Client-side validation ensures type/value compatibility
+  PTR, NS, CAA, and FWD record types. Client-side validation ensures type/value compatibility
   before API calls.
 ---
 
 # technitium\_record (Resource)
 
-Manages a DNS record in a Technitium DNS zone. Supports A, AAAA, CNAME, MX, TXT, SRV, PTR, NS, and CAA record types. Client-side validation ensures type/value compatibility before API calls.
+Manages a DNS record in a Technitium DNS zone. Supports A, AAAA, CNAME, MX, TXT, SRV, PTR, NS, CAA, and FWD record types. Client-side validation ensures type/value compatibility before API calls.
 
 -> The `overwrite` attribute controls whether this record replaces existing records of the same type at the same name. Default is `true`.
 
@@ -35,6 +35,10 @@ Manages a DNS record in a Technitium DNS zone. Supports A, AAAA, CNAME, MX, TXT,
 
 {{codefile "hcl" "examples/resources/technitium_record/multiple-types.tf"}}
 
+### FWD Forwarder Records
+
+{{codefile "hcl" "examples/resources/technitium_record/fwd-record.tf"}}
+
 ### Multiple Records at Same Name (Round-Robin)
 
 {{codefile "hcl" "examples/resources/technitium_record/round-robin.tf"}}
@@ -47,9 +51,9 @@ Manages a DNS record in a Technitium DNS zone. Supports A, AAAA, CNAME, MX, TXT,
 
 * `name` - (Required, String) FQDN for the record. (Forces replacement.)
 
-* `type` - (Required, String) Record type. Valid values: `A`, `AAAA`, `CNAME`, `MX`, `TXT`, `SRV`, `PTR`, `NS`, `CAA`. (Forces replacement.)
+* `type` - (Required, String) Record type. Valid values: `A`, `AAAA`, `CNAME`, `MX`, `TXT`, `SRV`, `PTR`, `NS`, `CAA`, `FWD`. (Forces replacement.)
 
-* `value` - (Required, String) Record data.
+* `value` - (Required, String) Record data. For `FWD`, this is the forwarder address using Technitium name-server address syntax, e.g. `1.1.1.1`, `dns.quad9.net:853 (9.9.9.9)`, or a DoH URL.
 
 * `ttl` - (Optional, Integer) TTL in seconds. Default: `3600`.
 
@@ -63,13 +67,21 @@ Manages a DNS record in a Technitium DNS zone. Supports A, AAAA, CNAME, MX, TXT,
 
 * `caa_tag` - (Optional, String) CAA tag. Valid values: `issue`, `issuewild`, `iodef`.
 
+* `protocol` - (Optional, String) Protocol for `FWD` records. Valid values: `Udp`, `Tcp`, `Tls`, `Https`, `Quic`.
+
+* `forwarder_priority` - (Optional, Integer) Priority for `FWD` records. Lower values are queried first.
+
+* `dnssec_validation` - (Optional, Boolean) Enable DNSSEC validation for `FWD` records.
+
+* `proxy_type`, `proxy_address`, `proxy_port`, `proxy_username`, `proxy_password` - (Optional) Proxy settings for `FWD` records. `proxy_password` is sensitive.
+
 * `overwrite` - (Optional, Boolean) Replace existing record set. Default: `true`.
 
 ## Attributes Reference
 
 In addition to the arguments above, the following computed attributes are exported:
 
-* `id` - Record identifier (`zone::name::type::value` composite key). For MX records: `zone::name::MX::exchange:priority`. For SRV records: `zone::name::SRV::target:priority:weight:port`. For CAA records: `zone::name::CAA::value:flags:tag`.
+* `id` - Record identifier (`zone::name::type::value` composite key). For MX records: `zone::name::MX::exchange:priority`. For SRV records: `zone::name::SRV::target:priority:weight:port`. For CAA records: `zone::name::CAA::value:flags:tag`. For FWD records: `zone::name::FWD::forwarder:protocol:priority`.
 
 * `last_modified` - Timestamp of last modification.
 
@@ -89,4 +101,7 @@ terraform import technitium_record.sip "example.com::_sip._tcp.example.com::SRV:
 
 # CAA record (value:flags:tag)
 terraform import technitium_record.caa "example.com::example.com::CAA::letsencrypt.org:0:issue"
+
+# FWD record (forwarder:protocol:priority)
+terraform import technitium_record.forwarder ".::.::FWD::1.1.1.1:Udp:2"
 ```

--- a/templates/resources/record.md.tmpl
+++ b/templates/resources/record.md.tmpl
@@ -73,7 +73,7 @@ records match on the first three:
 * **Changing one merges the two.** An in-place update rewrites one record onto the other,
   leaving a single record where there were two — again reported as success.
 
-Verified against Technitium DNS Server 15.4.
+Verified against Technitium DNS Server 15.2 and 15.4.
 
 **What the provider does about it.** Changing `dnssec_validation` is treated as requiring
 replacement, so the provider never issues the in-place update that merges records. That

--- a/templates/resources/record.md.tmpl
+++ b/templates/resources/record.md.tmpl
@@ -81,7 +81,7 @@ Manages a DNS record in a Technitium DNS zone. Supports A, AAAA, CNAME, MX, TXT,
 
 In addition to the arguments above, the following computed attributes are exported:
 
-* `id` - Record identifier (`zone::name::type::value` composite key). For MX records: `zone::name::MX::exchange:priority`. For SRV records: `zone::name::SRV::target:priority:weight:port`. For CAA records: `zone::name::CAA::value:flags:tag`. For FWD records: `zone::name::FWD::forwarder:protocol:priority`.
+* `id` - Record identifier (`zone::name::type::value` composite key). For MX records: `zone::name::MX::exchange:priority`. For SRV records: `zone::name::SRV::target:priority:weight:port`. For CAA records: `zone::name::CAA::value:flags:tag`. For FWD records: `zone::name::FWD::forwarder:protocol:priority:dnssecValidation`. The `dnssecValidation` field distinguishes otherwise-identical forwarders; the legacy 3-field form `forwarder:protocol:priority` is still accepted on import for backward compatibility.
 
 * `last_modified` - Timestamp of last modification.
 
@@ -102,6 +102,9 @@ terraform import technitium_record.sip "example.com::_sip._tcp.example.com::SRV:
 # CAA record (value:flags:tag)
 terraform import technitium_record.caa "example.com::example.com::CAA::letsencrypt.org:0:issue"
 
-# FWD record (forwarder:protocol:priority)
-terraform import technitium_record.forwarder ".::.::FWD::1.1.1.1:Udp:2"
+# FWD record (forwarder:protocol:priority:dnssecValidation)
+terraform import technitium_record.forwarder ".::.::FWD::1.1.1.1:Udp:2:true"
+
+# FWD record, legacy 3-field form (still accepted; dnssec_validation is left unset)
+terraform import technitium_record.forwarder_legacy ".::.::FWD::1.1.1.1:Udp:2"
 ```

--- a/templates/resources/record.md.tmpl
+++ b/templates/resources/record.md.tmpl
@@ -37,14 +37,29 @@ Manages a DNS record in a Technitium DNS zone. Supports A, AAAA, CNAME, MX, TXT,
 
 ### FWD Forwarder Records
 
+Forwarder zones are created empty; each upstream forwarder is then managed as its own
+`technitium_record` resource. The simplest case is a single forwarder:
+
+{{codefile "hcl" "examples/resources/technitium_record/fwd-record-simple.tf"}}
+
+A fuller example, with DNSSEC validation over DNS-over-TLS and a plain fallback:
+
 {{codefile "hcl" "examples/resources/technitium_record/fwd-record.tf"}}
+
+Conditional forwarding — send a single internal namespace to the resolvers authoritative
+for it, with a redundant pair of upstreams:
+
+{{codefile "hcl" "examples/resources/technitium_record/fwd-record-conditional.tf"}}
 
 #### DNSSEC validation on forwarders
 
-~> **Do not define two `FWD` records that share the same `value`, `protocol` and
-`forwarder_priority` and differ only by `dnssec_validation`.** Technitium cannot tell
-such records apart, and Terraform cannot protect you from it. You may silently lose a
-record.
+**If you have a single forwarder, none of this applies** — `dnssec_validation` is optional,
+and leaving it out is fine.
+
+~> **With several forwarders on one zone, do not let any two differ only by
+`dnssec_validation`.** If two `FWD` records share the same `value`, `protocol` and
+`forwarder_priority`, Technitium cannot tell them apart, and you may silently lose one.
+Terraform cannot protect you from it.
 
 You do not need to know anything about DNSSEC for this to affect you — it is enough that
 two forwarder records look identical apart from that one true/false setting.
@@ -67,8 +82,9 @@ cannot rescue a pair that already collides, because the API offers no way to add
 without the other.
 
 **How to stay safe.** Give forwarders that should coexist a distinguishing
-`forwarder_priority` (or a different `protocol`). Priority is part of the record's identity,
-so records that differ by it are addressed correctly:
+`forwarder_priority` (or a different `value` or `protocol`). All three are part of the
+record's identity, so records that differ by any of them are addressed correctly. Priority
+is usually the natural choice, since it also controls query order — lower is tried first:
 
 ```hcl
 resource "technitium_record" "validating" {

--- a/templates/resources/record.md.tmpl
+++ b/templates/resources/record.md.tmpl
@@ -39,6 +39,62 @@ Manages a DNS record in a Technitium DNS zone. Supports A, AAAA, CNAME, MX, TXT,
 
 {{codefile "hcl" "examples/resources/technitium_record/fwd-record.tf"}}
 
+#### DNSSEC validation on forwarders
+
+~> **Do not define two `FWD` records that share the same `value`, `protocol` and
+`forwarder_priority` and differ only by `dnssec_validation`.** Technitium cannot tell
+such records apart, and Terraform cannot protect you from it. You may silently lose a
+record.
+
+You do not need to know anything about DNSSEC for this to affect you — it is enough that
+two forwarder records look identical apart from that one true/false setting.
+
+**What goes wrong.** The Technitium API identifies a forwarder record by its forwarder
+address, protocol and priority. `dnssec_validation` is not part of that lookup, so when two
+records match on the first three:
+
+* **Destroying one destroys the wrong one.** The API deletes whichever record was created
+  first and reports success. Terraform believes it removed the resource you asked for.
+* **Changing one merges the two.** An in-place update rewrites one record onto the other,
+  leaving a single record where there were two — again reported as success.
+
+Verified against Technitium DNS Server 15.4.
+
+**What the provider does about it.** Changing `dnssec_validation` is treated as requiring
+replacement, so the provider never issues the in-place update that merges records. That
+protects the ordinary case of a single forwarder whose setting you want to change. It
+cannot rescue a pair that already collides, because the API offers no way to address one
+without the other.
+
+**How to stay safe.** Give forwarders that should coexist a distinguishing
+`forwarder_priority` (or a different `protocol`). Priority is part of the record's identity,
+so records that differ by it are addressed correctly:
+
+```hcl
+resource "technitium_record" "validating" {
+  zone               = technitium_zone.fwd.name
+  name               = technitium_zone.fwd.name
+  type               = "FWD"
+  value              = "1.1.1.1"
+  protocol           = "Udp"
+  forwarder_priority = 1
+  dnssec_validation  = true
+}
+
+resource "technitium_record" "non_validating" {
+  zone               = technitium_zone.fwd.name
+  name               = technitium_zone.fwd.name
+  type               = "FWD"
+  value              = "1.1.1.1"
+  protocol           = "Udp"
+  forwarder_priority = 2 # distinct priority keeps the two records addressable
+  dnssec_validation  = false
+}
+```
+
+If you have already created a colliding pair, remove both records and recreate them with
+distinct priorities rather than trying to delete one.
+
 ### Multiple Records at Same Name (Round-Robin)
 
 {{codefile "hcl" "examples/resources/technitium_record/round-robin.tf"}}
@@ -72,6 +128,9 @@ Manages a DNS record in a Technitium DNS zone. Supports A, AAAA, CNAME, MX, TXT,
 * `forwarder_priority` - (Optional, Integer) Priority for `FWD` records. Lower values are queried first.
 
 * `dnssec_validation` - (Optional, Boolean) Enable DNSSEC validation for `FWD` records.
+  Changing this value forces the record to be **replaced** (destroyed and recreated) rather
+  than updated in place. See [DNSSEC validation on forwarders](#dnssec-validation-on-forwarders)
+  before defining two forwarders that differ only by this setting.
 
 * `proxy_type`, `proxy_address`, `proxy_port`, `proxy_username`, `proxy_password` - (Optional) Proxy settings for `FWD` records. `proxy_password` is sensitive.
 


### PR DESCRIPTION
## Problem

Forwarder (FWD) records with identical forwarder, protocol, and priority but different DNSSEC validation flags were indistinguishable in Terraform state. This caused import collisions and incorrect state matching when multiple forwarders existed with only the DNSSEC flag differing.

## Changes

- buildRecordID: Appends dnssecValidation bool to FWD IDs (format: forwarder:protocol:priority:bool)
- parseImportValueSegment: Parses optional 4th dnssec field while maintaining backward compatibility with 3-field legacy IDs
- recordMatchesState: Matches on dnssecValidation field for FWD records
- ImportState: Sets dnssec_validation attribute when importing FWD records
- Unit tests: Added tests for build/parse/match with dnssec true/false and backward compat

## Backward Compatibility

Old 3-segment FWD import IDs (forwarder:protocol:priority) continue to parse correctly. The 4th dnssec field is optional.

## Testing

Unit tests added in record_id_test.go:
- TestBuildRecordID_FWD_DNSSEC - true/false variants
- TestParseImportValueSegment_FWD_DNSSEC - with/without dnssec, backward compat
- TestRecordMatchesState_FWD_DNSSEC - match/mismatch scenarios

Please verify with upstream CI runs.