### PR TITLE
chore(renovate): drop the release-age delay on container images

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,11 +10,12 @@
   },
   "packageRules": [
     {
+      "description": "Container images - no release-age delay. These are test fixtures (the Technitium server used by acceptance tests), not shipped dependencies, so a bad image fails CI rather than reaching users. Waiting only means testing against an image older than the one users run. pinDigests still applies, so every bump remains an explicit, reviewable digest change.",
       "matchCategories": [
         "docker"
       ],
       "pinDigests": true,
-      "minimumReleaseAge": "7 days"
+      "minimumReleaseAge": "0 days"
     },
     {
       "description": "FIPS-validated cryptography - manual review required",


### PR DESCRIPTION
Removes `minimumReleaseAge` from the docker `packageRule`. Library waits stay as they are.

## Why

Container images in this repo are **test fixtures, not shipped dependencies**. The only one in play is the Technitium DNS server the acceptance suite runs against. A bad image fails CI — it never reaches a user.

So the delay was buying nothing, and costing something real: it meant testing against an image *older* than the one users run.

That's not hypothetical. The pinned digest currently resolves to **Technitium 15.2** while **15.4** has been out for some time, so local and CI acceptance runs exercise a version two releases behind the field. **#73** — the digest bump that closes that gap — has been held by this rule since **2026-07-06**.

Upstream also has an open report that the `latest` tag itself lags releases ([TechnitiumSoftware/DnsServer#2065](https://github.com/TechnitiumSoftware/DnsServer/issues/2065)), which compounds the drift.

## What still protects us

`pinDigests` is unchanged. Every image bump remains an explicit, reviewable digest change rather than a floating tag — this removes the *wait*, not the scrutiny.

## Policy after this change

| Scope | Release-age delay | |
|---|---|---|
| github-actions | 3 days | unchanged |
| **docker** | **none** | **was 7 days** |
| FIPS-validated crypto | 7 days | unchanged, + manual review, no automerge |
| Security scanning tools | none | unchanged, automerge |
| Security patches | none | unchanged, automerge |

Library dependencies keep their waits. The reasoning that justifies a cooling-off period for code shipping to users doesn't transfer to a container the test harness starts and throws away.

## Follow-on

Once this merges, **#73** should be unblocked and can move the acceptance fixture onto a current Technitium image — worth doing before the next FWD-related change, since that's the surface where 15.2-vs-15.4 behaviour differences would matter most.