### PR TITLE
chore(stig): validate requirements against the July 2026 DNS STIG releases

### DIFF
--- a/docs/guides/stig-compliance.md
+++ b/docs/guides/stig-compliance.md
@@ -26,8 +26,28 @@ This provider derives its requirements from two STIGs:
 
 | STIG | Version / Release | Library Release Date |
 |---|---|---|
-| BIND 9.x STIG | V3R2 | 2026-04-01 |
-| Windows Server 2022 DNS STIG | V2R4 | 2026-04-01 |
+| BIND 9.x STIG | V3R3 | 2026-07-01 |
+| Windows Server 2022 DNS STIG | V2R5 | 2026-07-01 |
+
+Requirements were originally derived from BIND 9.x V3R2 and Windows Server 2022 DNS
+V2R4 (both 2026-04-01) and have been **re-validated against the July 2026 releases**
+above. Neither release adds or removes rules (BIND remains 73, Windows DNS 81), and
+all 42 STIG rules this provider cites are present and textually unchanged between the
+two revisions — so no requirement needed revision.
+
+The July releases do revise four rules, none of which this provider references:
+
+| Rule | Change | Why it is out of scope |
+|---|---|---|
+| `BIND-9X-001200` | check content | TSIG key **file ownership** on the DNS host |
+| `WDNS-22-000039` | check + fix | Filesystem access control on the **private key** |
+| `WDNS-22-000040` | check content | Key **file ownership** by the service account |
+| `WDNS-22-000043` | check content | Local **CRL cache** for PKI authentication |
+
+All four are host-level filesystem or PKI controls with no representation in the
+Technitium API, so they cannot be expressed as Terraform configuration and are not
+candidates for this engine. They are listed here so their absence is a recorded
+decision rather than an oversight.
 
 Dates above are the release dates published in the
 [DISA STIG Public Library](https://public.cyber.mil/stigs/downloads/) STIG

--- a/internal/provider/validators/stig_baselines_gen.go
+++ b/internal/provider/validators/stig_baselines_gen.go
@@ -2,8 +2,16 @@
 // SPDX-License-Identifier: MPL-2.0
 
 // Code generated from DISA STIG data; DO NOT EDIT.
-// Source: BIND 9.x STIG V3R2, Windows Server 2022 DNS STIG V2R4
-// Generated: 2026-05-23
+// Source: BIND 9.x STIG V3R3, Windows Server 2022 DNS STIG V2R5
+// Generated: 2026-05-23 (derived from V3R2 / V2R4)
+// Validated: 2026-07-26 against V3R3 / V2R5 — no requirement changes needed.
+//
+// The July 2026 releases add and remove no rules (BIND 73, Windows DNS 81 in both
+// revisions), and all 42 STIG rules cited below are present and textually unchanged
+// between V3R2->V3R3 and V2R4->V2R5. The four rules that did change
+// (BIND-9X-001200, WDNS-22-000039, WDNS-22-000040, WDNS-22-000043) are host-level
+// file-ownership and PKI-cache controls with no Technitium API representation, so
+// none are referenced here. See docs/guides/stig-compliance.md.
 
 package validators
 

--- a/templates/guides/stig-compliance.md.tmpl
+++ b/templates/guides/stig-compliance.md.tmpl
@@ -26,8 +26,28 @@ This provider derives its requirements from two STIGs:
 
 | STIG | Version / Release | Library Release Date |
 |---|---|---|
-| BIND 9.x STIG | V3R2 | 2026-04-01 |
-| Windows Server 2022 DNS STIG | V2R4 | 2026-04-01 |
+| BIND 9.x STIG | V3R3 | 2026-07-01 |
+| Windows Server 2022 DNS STIG | V2R5 | 2026-07-01 |
+
+Requirements were originally derived from BIND 9.x V3R2 and Windows Server 2022 DNS
+V2R4 (both 2026-04-01) and have been **re-validated against the July 2026 releases**
+above. Neither release adds or removes rules (BIND remains 73, Windows DNS 81), and
+all 42 STIG rules this provider cites are present and textually unchanged between the
+two revisions — so no requirement needed revision.
+
+The July releases do revise four rules, none of which this provider references:
+
+| Rule | Change | Why it is out of scope |
+|---|---|---|
+| `BIND-9X-001200` | check content | TSIG key **file ownership** on the DNS host |
+| `WDNS-22-000039` | check + fix | Filesystem access control on the **private key** |
+| `WDNS-22-000040` | check content | Key **file ownership** by the service account |
+| `WDNS-22-000043` | check content | Local **CRL cache** for PKI authentication |
+
+All four are host-level filesystem or PKI controls with no representation in the
+Technitium API, so they cannot be expressed as Terraform configuration and are not
+candidates for this engine. They are listed here so their absence is a recorded
+decision rather than an oversight.
 
 Dates above are the release dates published in the
 [DISA STIG Public Library](https://public.cyber.mil/stigs/downloads/) STIG


### PR DESCRIPTION
DISA published **BIND 9.x V3R3** and **Windows Server 2022 DNS V2R5** on 2026-07-01. The engine's requirements were derived from V3R2 / V2R4 (2026-04-01). This records the re-validation — **no requirement needed changing.**

## Method

Diffed both revisions rule-by-rule out of the Security MCP STIG library, which has all four benchmark revisions imported. That's the same source `tools/generate_stig_baselines.go` is designed to query.

## Findings

| | |
|---|---|
| Rule counts | BIND **73 → 73**, Windows DNS **81 → 81** |
| Rules added | **0** |
| Rules removed | **0** |
| Severity changes | **0** |
| Title changes | **0** |
| Provider-cited rules | **42** distinct STIG IDs |
| …missing from new STIGs | **0** |
| …changed old → new | **0** |

## The four rules that did change — none cited here

| Rule | Change | Why out of scope |
|---|---|---|
| `BIND-9X-001200` | check content | TSIG key **file ownership** on the DNS host |
| `WDNS-22-000039` | check + fix | Filesystem access control on the **private key** |
| `WDNS-22-000040` | check content | Key **file ownership** by the service account |
| `WDNS-22-000043` | check content | Local **CRL cache** for PKI authentication |

All four are host-level filesystem or PKI controls with no representation in the Technitium API. They cannot be expressed as Terraform configuration, so they are not candidates for this engine.

Documented explicitly rather than silently omitted: a future reviewer diffing these STIGs will land on exactly these four rules and wonder why they aren't covered. Better that the answer is written down.

## Why the version citations move

`V3R3` / `V2R5` are now cited because **equivalence was verified for every cited rule**, not because the release is newer. Had any of the 42 changed, this PR would carry requirement updates instead.

## Note for the next refresh

`tools/generate_stig_baselines.go` is still a stub — the baselines are hand-written, so this validation was done by querying the STIG library directly rather than regenerating. The 42-rule cross-check is entirely mechanical and worth automating before the next quarterly release.

## Verification

build · vet · `golangci-lint` (0 issues) · all unit packages · `Verify Docs` idempotent.