### PR TITLE
docs(readme): update STIG version table to V3R3 / V2R5

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ and `terraform plan` time, catching misconfigurations before they reach your DNS
 
 | STIG | Version | Library Release Date |
 |---|---|---|
-| [BIND 9.x STIG](https://www.cyber.mil/stigs) | V3R2 | 2026-04-01 |
-| [Windows Server 2022 DNS STIG](https://www.cyber.mil/stigs) | V2R4 | 2026-04-01 |
+| [BIND 9.x STIG](https://www.cyber.mil/stigs) | V3R3 | 2026-07-01 |
+| [Windows Server 2022 DNS STIG](https://www.cyber.mil/stigs) | V2R5 | 2026-07-01 |
 
 Dates are the release dates published in the
 [DISA STIG Public Library](https://public.cyber.mil/stigs/downloads/)


### PR DESCRIPTION
Follow-up to #83. That PR validated the requirements against the July 2026 STIG releases and updated the compliance guide and the generated baselines header — **but left the README advertising V3R2 / V2R4 (2026-04-01).**

```
| [BIND 9.x STIG]              | V3R2 | 2026-04-01 |   →  V3R3 | 2026-07-01
| [Windows Server 2022 DNS STIG] | V2R4 | 2026-04-01 |   →  V2R5 | 2026-07-01
```

## Why this one matters more than most stale text

The README table is the first thing a prospective user reads about this provider's compliance posture, and it's the copy most likely to end up quoted in an ATO package. Under-stating currency there is worse than in a guide.

## How it was missed

The version update in #83 was made by searching `templates/` and `docs/` — the directories being edited — rather than grepping the whole repository for the strings being replaced.

Swept properly this time. Every remaining `V3R2` / `V2R4` mention is deliberate:

| Location | Why it stays |
|---|---|
| `CHANGELOG.md` | Records 1.2.0's V3R1 → V3R2 refresh — historical |
| `docs/guides/stig-compliance.md` + template | *"originally derived from V3R2 / V2R4 and re-validated against the July releases"* |
| `stig_baselines_gen.go` | Same derivation and validation note |

README, the guide, and the generated source now agree on V3R3 / V2R5.

Docs-only; `make generate` remains a no-op.